### PR TITLE
Convert character encoding of all files: EUC-JP to UTF-8

### DIFF
--- a/datefield.inc.php/datefield.inc.php
+++ b/datefield.inc.php/datefield.inc.php
@@ -5,28 +5,28 @@
 // $Id: datefield.inc.php,v 1.5 2006/03/23 21:10:25 jjyun Exp $
 //
 
-/* [³µÎ¬¤ÎÀâÌÀ]
- * ÆüÉÕÆşÎÏÊä½õ²èÌÌÉÕ¤­¥Õ¥£¡¼¥ë¥ÉÄó¶¡¥×¥é¥°¥¤¥ó 
+/* [æ¦‚ç•¥ã®èª¬æ˜]
+ * æ—¥ä»˜å…¥åŠ›è£œåŠ©ç”»é¢ä»˜ããƒ•ã‚£ãƒ¼ãƒ«ãƒ‰æä¾›ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ 
  *    for pukiwiki-1.4.6
  *
- * ÆüÉÕÆşÎÏ¤ò¹Ô¤ï¤»¤¿¤¤¥Æ¥­¥¹¥È¥Õ¥£¡¼¥ë¥É¤È¡¢
- * ÆüÉÕÆşÎÏ¤ò¹Ô¤¦¤¿¤á¤Î¥«¥ì¥ó¥À¡¼¤òÉ½¼¨¤¹¤ë¥Ü¥¿¥ó¤òÄó¶¡¤·¤Ş¤¹¡£
- * ¥«¥ì¥ó¥À¡¼¤Ë¤è¤ëÆüÉÕÆşÎÏ¤Ë¤è¤ê,³ºÅö¥Ú¡¼¥¸¤Î¹¹¿·¤¬¹Ô¤ï¤ì¤Ş¤¹¡£
- * ¥«¥ì¥ó¥À¡¼¤Ø¤Î°ú¿ô¤Ë¤Ï¡¢¥Æ¥­¥¹¥È¥Õ¥£¡¼¥ë¥É¤Ø¤ÎÆşÎÏÃÍ
- * ÆüÉÕ½ñ¼°(¥Ç¥Õ¥©¥ë¥ÈÃÍ(¥Ö¥é¥ó¥¯²ÄÇ½),[ÆüÉÕ½ñ¼°ÀßÄê])
+ * æ—¥ä»˜å…¥åŠ›ã‚’è¡Œã‚ã›ãŸã„ãƒ†ã‚­ã‚¹ãƒˆãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ã¨ã€
+ * æ—¥ä»˜å…¥åŠ›ã‚’è¡Œã†ãŸã‚ã®ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼ã‚’è¡¨ç¤ºã™ã‚‹ãƒœã‚¿ãƒ³ã‚’æä¾›ã—ã¾ã™ã€‚
+ * ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼ã«ã‚ˆã‚‹æ—¥ä»˜å…¥åŠ›ã«ã‚ˆã‚Š,è©²å½“ãƒšãƒ¼ã‚¸ã®æ›´æ–°ãŒè¡Œã‚ã‚Œã¾ã™ã€‚
+ * ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼ã¸ã®å¼•æ•°ã«ã¯ã€ãƒ†ã‚­ã‚¹ãƒˆãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ã¸ã®å…¥åŠ›å€¤
+ * æ—¥ä»˜æ›¸å¼(ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆå€¤(ãƒ–ãƒ©ãƒ³ã‚¯å¯èƒ½),[æ—¥ä»˜æ›¸å¼è¨­å®š])
  * 
- * À©¸Â¡§JavaScript ¤ò»È¤Ã¤Æ¤¤¤ë¤Î¤¿¤á,
- * Javascript¤¬»ÈÍÑ¤Ç¤­¤ë´Ä¶­¤Ç¤Ê¤±¤ì¤ĞÆ°¤­¤Ş¤»¤ó¡£
+ * åˆ¶é™ï¼šJavaScript ã‚’ä½¿ã£ã¦ã„ã‚‹ã®ãŸã‚,
+ * JavascriptãŒä½¿ç”¨ã§ãã‚‹ç’°å¢ƒã§ãªã‘ã‚Œã°å‹•ãã¾ã›ã‚“ã€‚
  * 
- * ¥Ö¥é¥¦¥¶Â¦¤ÎÀßÄê¤ÎÂ¾¤Ë¡¢¥µ¡¼¥ĞÂ¦¤ÎÀßÄê¤È¤·¤Æ
- * pukiwiki.ini.php ¤Î PKWK_ALLOW_JAVASCRIPT ¤ò°Ê²¼¤ÎÀßÄê¤Ë¤¹¤ëÉ¬Í×¤¬¤¢¤ê¤Ş¤¹
+ * ãƒ–ãƒ©ã‚¦ã‚¶å´ã®è¨­å®šã®ä»–ã«ã€ã‚µãƒ¼ãƒå´ã®è¨­å®šã¨ã—ã¦
+ * pukiwiki.ini.php ã® PKWK_ALLOW_JAVASCRIPT ã‚’ä»¥ä¸‹ã®è¨­å®šã«ã™ã‚‹å¿…è¦ãŒã‚ã‚Šã¾ã™
  *   define('PKWK_ALLOW_JAVASCRIPT', 1);     // 0 or 1
  */ 
 
-// ½¤Àµ¸å¤Î¥ê¥í¡¼¥É»ş¤Ë¡¢ÊÔ½¸²Õ½ê¤ØÉ½¼¨²Õ½ê¤ò°Ü¤¹
-// Í­¸ú¤Ë¤¹¤ë¾ì¹ç¤Ë¤Ï¡¢TRUE , Ìµ¸ú¤Ë¤¹¤ë¾ì¹ç¤Ë¤Ï FALSE ¤ò»ØÄê
+// ä¿®æ­£å¾Œã®ãƒªãƒ­ãƒ¼ãƒ‰æ™‚ã«ã€ç·¨é›†ç®‡æ‰€ã¸è¡¨ç¤ºç®‡æ‰€ã‚’ç§»ã™
+// æœ‰åŠ¹ã«ã™ã‚‹å ´åˆã«ã¯ã€TRUE , ç„¡åŠ¹ã«ã™ã‚‹å ´åˆã«ã¯ FALSE ã‚’æŒ‡å®š
 define('DATEFIELD_JUMP_TO_MODIFIED_PLACE',FALSE); // TRUE or FALSE
-// ¥â¡¼¥ÉÊÑ¹¹¤òÅ¬ÍÑ¤¹¤ë
+// ãƒ¢ãƒ¼ãƒ‰å¤‰æ›´ã‚’é©ç”¨ã™ã‚‹
 define('DATEFIELD_APPLY_MODECHANGE',TRUE); // TRUE or FALSE
 
 function plugin_datefield_init()
@@ -53,18 +53,18 @@ function plugin_datefield_init_ja()
 {
 	$msg = array(
 		'_datefield_msg' => array(
-			'format_not_effective'        => "ÆüÉÕ½ñ¼°Ê¸»úÎó %s ¤Ë¥¯¥©¡¼¥ÈÊ¸»ú(&nbsp;&#039;&nbsp;&quot;&nbsp;)¤ò»ÈÍÑ¤·¤Ê¤¤¤Ç¤¯¤À¤µ¤¤¡£" ,
-			'input_pattern_not_effective' =>  "ÆşÎÏÃÍ¤¬ÆüÉÕ½ñ¼° %s ¤È¹çÃ×¤·¤Ş¤»¤ó¡£<br />"
-												+ "¥¼¥í¥Ñ¥Ç¥£¥ó¥°¤â¹ÍÎ¸¤·¤Æ¤¯¤À¤µ¤¤¡£",
-			'datecheck_irregular_error' => "ÆüÉÕ³ÎÇ§»ş¤ÎÁÛÄê³°¥¨¥é¡¼¤Ç¤¹¡£<br />" 
-												+ "³ÎÇ§ÂĞ¾İÊ¸»úÎó: %s <br />"
-												+ "ÆüÉÕ½ñ¼°Ê¸»úÎó: %s <br />"
-												+ "°ú¼õÊÑ¿ôÊ¸»úÎó: %s <br />"
-												+ "¥Ñ¡¼¥¹½ñ¼°¾õÂÖ: %s <br />"
-												+ "ÆÉ¤ß¼è¤ê¾õÂÖ:year = %s, month = %s, day = %s<br />",
-			'datecheck_not_effective_month' => "·î¤Î»ØÄê %s ¤¬ÄÌ¾ï¼è¤êÆÀ¤ëÃÍ¤«¤é³°¤ì¤Æ¤¤¤Ş¤¹¡£", 
-			'datecheck_not_effective_day'   => "ÆüÉÕ¤Î»ØÄê %s ¤¬ÄÌ¾ï¼è¤êÆÀ¤ëÃÍ¤«¤é³°¤ì¤Æ¤¤¤Ş¤¹¡£", 
-			'datecheck_not_effective_date'  => "ÆşÎÏÆüÉÕ %s ¤¬ÉÔÅ¬ÀÚ¤Ç¤¹¡£",
+			'format_not_effective'        => "æ—¥ä»˜æ›¸å¼æ–‡å­—åˆ— %s ã«ã‚¯ã‚©ãƒ¼ãƒˆæ–‡å­—(&nbsp;&#039;&nbsp;&quot;&nbsp;)ã‚’ä½¿ç”¨ã—ãªã„ã§ãã ã•ã„ã€‚" ,
+			'input_pattern_not_effective' =>  "å…¥åŠ›å€¤ãŒæ—¥ä»˜æ›¸å¼ %s ã¨åˆè‡´ã—ã¾ã›ã‚“ã€‚<br />"
+												+ "ã‚¼ãƒ­ãƒ‘ãƒ‡ã‚£ãƒ³ã‚°ã‚‚è€ƒæ…®ã—ã¦ãã ã•ã„ã€‚",
+			'datecheck_irregular_error' => "æ—¥ä»˜ç¢ºèªæ™‚ã®æƒ³å®šå¤–ã‚¨ãƒ©ãƒ¼ã§ã™ã€‚<br />" 
+												+ "ç¢ºèªå¯¾è±¡æ–‡å­—åˆ—: %s <br />"
+												+ "æ—¥ä»˜æ›¸å¼æ–‡å­—åˆ—: %s <br />"
+												+ "å¼•å—å¤‰æ•°æ–‡å­—åˆ—: %s <br />"
+												+ "ãƒ‘ãƒ¼ã‚¹æ›¸å¼çŠ¶æ…‹: %s <br />"
+												+ "èª­ã¿å–ã‚ŠçŠ¶æ…‹:year = %s, month = %s, day = %s<br />",
+			'datecheck_not_effective_month' => "æœˆã®æŒ‡å®š %s ãŒé€šå¸¸å–ã‚Šå¾—ã‚‹å€¤ã‹ã‚‰å¤–ã‚Œã¦ã„ã¾ã™ã€‚", 
+			'datecheck_not_effective_day'   => "æ—¥ä»˜ã®æŒ‡å®š %s ãŒé€šå¸¸å–ã‚Šå¾—ã‚‹å€¤ã‹ã‚‰å¤–ã‚Œã¦ã„ã¾ã™ã€‚", 
+			'datecheck_not_effective_date'  => "å…¥åŠ›æ—¥ä»˜ %s ãŒä¸é©åˆ‡ã§ã™ã€‚",
 			)
 		);
 	return $msg;
@@ -114,7 +114,7 @@ function plugin_datefield_action() {
 				$opt = $match[1];
 				if ($vars['number'] == $number++)
 				{
-					//¥¿¡¼¥²¥Ã¥È¤Î¥×¥é¥°¥¤¥óÉôÊ¬
+					//ã‚¿ãƒ¼ã‚²ãƒƒãƒˆã®ãƒ—ãƒ©ã‚°ã‚¤ãƒ³éƒ¨åˆ†
 					$para_array = preg_split('/,/',$opt);
 					$errmsg = plugin_datefield_chkFormat($vars['infield'],$para_array[1]);
 					if( strlen($errmsg) > 0 )
@@ -140,8 +140,8 @@ function plugin_datefield_action() {
 }
 
 /* * function plugin_datefield_chkFormat($chkedStr, $formatStr) 
- * ÆüÉÕ(³ÎÇ§ÂĞ¾İ)Ê¸»úÎó¤ÈÆüÉÕ½ñ¼°Ê¸»úÎó¤Î³ÎÇ§¤ò¹Ô¤¦
- * ÌäÂê¤¬¤Ê¤±¤ì¤Ğ¶õÊ¸»úÎó¤ò¡¢ÉÔ¶ñ¹ç¤¬¤¢¤ì¤Ğ¤½¤ÎÆâÍÆ¤ò¼¨¤¹Ê¸»úÎó¤òÊÖ¤¹
+ * æ—¥ä»˜(ç¢ºèªå¯¾è±¡)æ–‡å­—åˆ—ã¨æ—¥ä»˜æ›¸å¼æ–‡å­—åˆ—ã®ç¢ºèªã‚’è¡Œã†
+ * å•é¡ŒãŒãªã‘ã‚Œã°ç©ºæ–‡å­—åˆ—ã‚’ã€ä¸å…·åˆãŒã‚ã‚Œã°ãã®å†…å®¹ã‚’ç¤ºã™æ–‡å­—åˆ—ã‚’è¿”ã™
  */
 function plugin_datefield_chkFormat($chkedStr, $formatStr)
 {
@@ -153,14 +153,14 @@ function plugin_datefield_chkFormat($chkedStr, $formatStr)
 	if( strlen($formatStr) == 0) $formatStr='YYYY/MM/DD';
 	$formatReg = $formatStr;
 
-	/* ¥¯¥©¡¼¥ÈÊ¸»ú ¤ÎÂ¸ºß³ÎÇ§ */
+	/* ã‚¯ã‚©ãƒ¼ãƒˆæ–‡å­— ã®å­˜åœ¨ç¢ºèª */
 	if(preg_match('/^.*[\'\"].*$/',$formatReg) ) /* match character..." ' */ 
 	{ 
 		$errmsg = sprintf($_datefield_msg['format_not_effective'], $formatStr);
 		return $errmsg;
 	}
 
-	/* ÆşÎÏÃÍ¤ÈÆüÉÕ½ñ¼°¤È¤ÎÈæ³Ó */
+	/* å…¥åŠ›å€¤ã¨æ—¥ä»˜æ›¸å¼ã¨ã®æ¯”è¼ƒ */
 	$formatReg = preg_replace('/\//','\\/',$formatReg);
 	$formatReg = '/^' . preg_replace('/[YMD]/i','\\d',$formatReg) .'$/';
 	if( ! preg_match($formatReg,$chkedStr) )
@@ -183,13 +183,13 @@ function plugin_datefield_chkFormat($chkedStr, $formatStr)
 	}
 	else if($month <= 0 or $month > 12)
 	{
-		/* ·î¤Î»ØÄê¤ÏÉ¬¿Ü */
+		/* æœˆã®æŒ‡å®šã¯å¿…é ˆ */
 		$errmsg = sprintf($_datefield_msg['datecheck_not_effective_month'], $chkedStr );
 		return $errmsg;
 	}
 	else
 	{
-		/* ·î»ØÄê¤¬¤¢¤ë¾õÂÖ */
+		/* æœˆæŒ‡å®šãŒã‚ã‚‹çŠ¶æ…‹ */
 		if( $day > 31)
 		{
 				$errmsg = sprintf($_datefield_msg['datecheck_not_effective_day'], $chkedStr );
@@ -197,7 +197,7 @@ function plugin_datefield_chkFormat($chkedStr, $formatStr)
 		}
 		else
 		{
-				/* »ØÄê¤¬¤Ê¤¤»ş¤Ï Êä´Ö¤¹¤ë */
+				/* æŒ‡å®šãŒãªã„æ™‚ã¯ è£œé–“ã™ã‚‹ */
 				if($year == -1) $year = date("Y",time());
 				if($day  == -1) $day  = 1;
 				if (! checkdate( $month, $day , $year) )
@@ -236,7 +236,7 @@ function plugin_datefield_getDate($dateStr, $formatStr)
 	$dateArgs =  preg_replace('/DD/i',',\$day',$dateArgs);
 	$dateArgs =  preg_replace('/[^(?!:,\$year|,\$month|,\$day)]+/','',$dateArgs);
 
-	// ¶èÀÚ¤êÊ¸»ú¤¬ '/'(¥Ğ¥Ã¥¯¥¹¥é¥Ã¥·¥å)¤Î¾ì¹ç¤Ï¥¨¥¹¥±¡¼¥×Ê¸»ú¤òÉÕÍ¿¤¹¤ë
+	// åŒºåˆ‡ã‚Šæ–‡å­—ãŒ '/'(ãƒãƒƒã‚¯ã‚¹ãƒ©ãƒƒã‚·ãƒ¥)ã®å ´åˆã¯ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—æ–‡å­—ã‚’ä»˜ä¸ã™ã‚‹
 	$scanStr = preg_replace('/\//','\\/',$dateStr);
 
 	if(! strcmp($scanStr,$formatPtn) == 0)
@@ -257,14 +257,14 @@ function plugin_datefield_getDate($dateStr, $formatStr)
 	return $date;
 }
 
-// headerÀë¸À¤ÎÃæ¤Ç°Ê²¼¤Î£²¤Ä¤ÎÄêµÁ¤ò¹Ô¤¦
-// ¡¦Javascipt¤òÍÑ¤¤¤ë¤³¤È¡¢
-// ¡¦XHTML1.0 Transitional Mode¤Ç¤ÎÆ°ºî¡Ê<form>¥¿¥°¤ËnameÂ°À­¤òÍÑ¤¤¤ë¡Ë
+// headerå®£è¨€ã®ä¸­ã§ä»¥ä¸‹ã®ï¼’ã¤ã®å®šç¾©ã‚’è¡Œã†
+// ãƒ»Javasciptã‚’ç”¨ã„ã‚‹ã“ã¨ã€
+// ãƒ»XHTML1.0 Transitional Modeã§ã®å‹•ä½œï¼ˆ<form>ã‚¿ã‚°ã«nameå±æ€§ã‚’ç”¨ã„ã‚‹ï¼‰
 function plugin_datefield_headDeclaration()
 {
 	global $pkwk_dtd, $javascript, $head_tags;
 
-	// Javascipt¤òÍÑ¤¤¤ë¤³¤È¡¢<form>¥¿¥°¤ËnameÂ°À­¤òÍÑ¤¤¤ë¤³¤È¤òÄÌÃÎ¤¹¤ë
+	// Javasciptã‚’ç”¨ã„ã‚‹ã“ã¨ã€<form>ã‚¿ã‚°ã«nameå±æ€§ã‚’ç”¨ã„ã‚‹ã“ã¨ã‚’é€šçŸ¥ã™ã‚‹
 	if( PKWK_ALLOW_JAVASCRIPT && DATEFIELD_APPLY_MODECHANGE )
 	{
 		// XHTML 1.0 Transitional
@@ -273,11 +273,11 @@ function plugin_datefield_headDeclaration()
 			$pkwk_dtd = PKWK_DTD_XHTML_1_0_TRANSITIONAL;
 		}
     
-		// <head> ¥¿¥°Æâ¤Ø¤Î <meta>Àë¸À¤ÎÄÉ²Ã
+		// <head> ã‚¿ã‚°å†…ã¸ã® <meta>å®£è¨€ã®è¿½åŠ 
 		$javascript = TRUE;
 	}
 
-	// <head> ¥¿¥°Æâ¤Ø¤Î <meta>Àë¸À¤ÎÄÉ²Ã
+	// <head> ã‚¿ã‚°å†…ã¸ã® <meta>å®£è¨€ã®è¿½åŠ 
 	$meta_str =
 		" <meta http-equiv=\"content-script-type\" content=\"text/javascript\" /> ";
 	if(! in_array($meta_str, $head_tags) )
@@ -289,10 +289,10 @@ function plugin_datefield_headDeclaration()
 
 function plugin_datefield_convert()
 {
-	// Javascipt¤òÍÑ¤¤¤ë¤³¤È¡¢<form>¥¿¥°¤ËnameÂ°À­¤òÍÑ¤¤¤ë¤³¤È¤òÄÌÃÎ¤¹¤ë
+	// Javasciptã‚’ç”¨ã„ã‚‹ã“ã¨ã€<form>ã‚¿ã‚°ã«nameå±æ€§ã‚’ç”¨ã„ã‚‹ã“ã¨ã‚’é€šçŸ¥ã™ã‚‹
 	plugin_datefield_headDeclaration();
   
-	// datefield ¥×¥é¥°¥¤¥ó¤ÎÉôÊ¬¤ÎHTML½ĞÎÏ
+	// datefield ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®éƒ¨åˆ†ã®HTMLå‡ºåŠ›
 	$number = plugin_datefield_getNumber();
 	if(func_num_args() > 0) 
     {
@@ -340,22 +340,22 @@ function plugin_datefield_getBody($number, $value, $format_opt, $caldsp_opt = ''
 	$page_enc = htmlspecialchars($vars['page']);
 	$script_enc = htmlspecialchars($script);
 	
-	// datefield ÍÑ¤Î<script>¥¿¥°¤ÎÁŞÆş
+	// datefield ç”¨ã®<script>ã‚¿ã‚°ã®æŒ¿å…¥
 	$extrascript = (PKWK_ALLOW_JAVASCRIPT && DATEFIELD_APPLY_MODECHANGE && $number == 0) ? plugin_datefield_getScript() : '';
 
-	// ÆüÉÕ½ñ¼°»ØÄêÊ¸»úÎó¤ËÂĞ¤¹¤ë½èÍı
+	// æ—¥ä»˜æ›¸å¼æŒ‡å®šæ–‡å­—åˆ—ã«å¯¾ã™ã‚‹å‡¦ç†
 	$format_opt= plugin_datefield_formFormat($format_opt);
 	
-	// ¥«¥ì¥ó¥À¡¼É½¼¨ÀßÄê¤ËÂĞ¤¹¤ë½èÍı
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼è¡¨ç¤ºè¨­å®šã«å¯¾ã™ã‚‹å‡¦ç†
 	if($caldsp_opt != 'CUR') $caldsp_opt = 'REL';
 
-	// ÊİÂ¸¤µ¤ì¤¿ÆüÉÕ¤«¤éÃÍ¤ò¼èÆÀ
+	// ä¿å­˜ã•ã‚ŒãŸæ—¥ä»˜ã‹ã‚‰å€¤ã‚’å–å¾—
 	$formatStr =substr($format_opt,1,strlen($format_opt)-2);
 	$errmsg = plugin_datefield_chkFormat($value,$formatStr);
 	if( strlen($value) != 0 && strlen($errmsg) == 0 and $caldsp_opt == 'REL')
 	{
 		$date= plugin_datefield_getDate($value, $formatStr);
-		/* »ØÄê¤¬¤Ê¤¤»ş¤Ï Êä´Ö¤¹¤ë */
+		/* æŒ‡å®šãŒãªã„æ™‚ã¯ è£œé–“ã™ã‚‹ */
 		if($date['year'] == -1) $date['year'] = date("Y",time());
 		if($date['day']  == -1) $date['day']  = 1;
 	}

--- a/datefield.inc.php/datefield.js-layer
+++ b/datefield.inc.php/datefield.js-layer
@@ -16,8 +16,8 @@
  */
 
 // ===================================================================
-// Layer Version ÍÑ¥³¡¼¥É
-// DOM= 0 or 1 ¤Ï¤³¤Î¥¹¥¯¥ê¥×¥È¤Ç¤ÏÂĞ±ş³°¤È¤·¤Ş¤¹¡£
+// Layer Version ç”¨ã‚³ãƒ¼ãƒ‰
+// DOM= 0 or 1 ã¯ã“ã®ã‚¹ã‚¯ãƒªãƒ—ãƒˆã§ã¯å¯¾å¿œå¤–ã¨ã—ã¾ã™ã€‚
 // Functions for CrossBrowser-----------------------------------------
 var DOM, isMOZ;
 // DOM: 1=NN4, 2=IE4, 3=IE5+, 4=NN6+, 0=Others
@@ -28,8 +28,8 @@ DOM = document.all ?
 isMOZ  = navigator.userAgent.indexOf('Gecko') != -1 ? true : false;
 
 // ===================================================================
-// === UI¥³¥ó¥È¥í¡¼¥ëÉôÊ¬(Å¬µ¹½¤Àµ¤·¤Æ¤¯¤À¤µ¤¤) ======================
-// ¥«¥ì¥ó¥À½Ğ¸½°ÌÃÖ¤ÎÄ´À° (ÆşÎÏ¥Æ¥­¥¹¥ÈÉôÊ¬¤«¤é¤ÎOffset)
+// === UIã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«éƒ¨åˆ†(é©å®œä¿®æ­£ã—ã¦ãã ã•ã„) ======================
+// ã‚«ãƒ¬ãƒ³ãƒ€å‡ºç¾ä½ç½®ã®èª¿æ•´ (å…¥åŠ›ãƒ†ã‚­ã‚¹ãƒˆéƒ¨åˆ†ã‹ã‚‰ã®Offset)
 _plugin_datefield_dspCalendar.offsetX = 50;
 _plugin_datefield_dspCalendar.offsetY = 30;
 
@@ -43,18 +43,18 @@ if(document.layers)
 _plugin_datefield_dragLay = new _plugin_datefield_dragLay(-100,-100);
 
 /********************************************************************
- * ¥É¥é¥Ã¥°²ÄÇ½¤Ê¥ì¥¤¥ä¡¼¤ÎºîÀ®
+ * ãƒ‰ãƒ©ãƒƒã‚°å¯èƒ½ãªãƒ¬ã‚¤ãƒ¤ãƒ¼ã®ä½œæˆ
  *  Syntax : _plugin_datefield_dragLay( x , y )
- *  Îã     : _plugin_datefield_dragLay( 100 , 100 )
+ *  ä¾‹     : _plugin_datefield_dragLay( 100 , 100 )
  * ------------------------------------------------------------------
  */
 function _plugin_datefield_dragLay( x, y)
 {
 	if( DOM <= 1 ) return null;
 
-	this.layerName = 'calendar';   // ¥É¥é¥Ã¥°¤Ç¤­¤ë¤è¤¦¤Ë¤¹¤ë¥ì¥¤¥ä¡¼Ì¾
-	this.posX    = x;  // ½é´üleft°ÌÃÖ
-	this.posY    = y;  // ½é´ütop°ÌÃÖ
+	this.layerName = 'calendar';   // ãƒ‰ãƒ©ãƒƒã‚°ã§ãã‚‹ã‚ˆã†ã«ã™ã‚‹ãƒ¬ã‚¤ãƒ¤ãƒ¼å
+	this.posX    = x;  // åˆæœŸleftä½ç½®
+	this.posY    = y;  // åˆæœŸtopä½ç½®
 	var _offsetX = 0;
 	var _offsetY = 0;
 	var _zcount  = 0;
@@ -113,13 +113,13 @@ function _plugin_datefield_dragLay( x, y)
 		return 0;
 	}
 	
-	// -- ¥ì¥¤¥ä¤ÎÉ½¼¨Â°À­¤ÎÀßÄê
+	// -- ãƒ¬ã‚¤ãƒ¤ã®è¡¨ç¤ºå±æ€§ã®è¨­å®š
 	function _setDivVisibility(visible)
 	{
 		if( DOM > 0 ) divID.style.visibility = (visible) ? 'visible' : 'hidden';
 	}
 	
-	// -- ±ü¹Ô¤­É½¼¨¤ÎÀßÄê
+	// -- å¥¥è¡Œãè¡¨ç¤ºã®è¨­å®š
 	function _setDivZIndex(order)
 	{
 		divID.style.zIndex=order;
@@ -155,12 +155,12 @@ function _plugin_datefield_dragLay( x, y)
 	}
 	
 	
-	//--¥Ş¥¦¥¹¥Ü¥¿¥ó¤ò²¡¤·²¼¤²¤¿»ş
-	//  ¥ì¥¤¥ä¡¼Æâ¤Î¥«¡¼¥½¥ëoffset°ÌÃÖ¼èÆÀ
+	//--ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³ã‚’æŠ¼ã—ä¸‹ã’ãŸæ™‚
+	//  ãƒ¬ã‚¤ãƒ¤ãƒ¼å†…ã®ã‚«ãƒ¼ã‚½ãƒ«offsetä½ç½®å–å¾—
 	function _mdown(e)
 	{
 		if(isMOZ)
-		{   //n6,m1ÍÑ
+		{   //n6,m1ç”¨
 			if(e.currentTarget.className != 'dragLays') return false;
 			else clickElement = e.currentTarget.id;
 		}
@@ -172,7 +172,7 @@ function _plugin_datefield_dragLay( x, y)
 		return false;
 	}
 
-	//--¥Ş¥¦¥¹¥Ü¥¿¥ó¤ò¾å¤²¤¿»ş¥É¥é¥Ã¥°²ò½ü
+	//--ãƒã‚¦ã‚¹ãƒœã‚¿ãƒ³ã‚’ä¸Šã’ãŸæ™‚ãƒ‰ãƒ©ãƒƒã‚°è§£é™¤
 	function _mup(e)
 	{
 		if( ! window.clickElement) return false;
@@ -184,16 +184,16 @@ function _plugin_datefield_dragLay( x, y)
 		return false;
 	}
 
-	//--¥¤¥Ù¥ó¥È¥­¥ã¥×¥Á¥ã¡¼³«»Ï
+	//--ã‚¤ãƒ™ãƒ³ãƒˆã‚­ãƒ£ãƒ—ãƒãƒ£ãƒ¼é–‹å§‹
 	function _setEventHandle()
 	{
 		document.onmousemove = _mmove;
 		document.onmouseup = _mup;
-		if(isMOZ) document.onmousedown = _mdown; //m1,n6ÍÑ
+		if(isMOZ) document.onmousedown = _mdown; //m1,n6ç”¨
 			
 	}
 
-	//--¥¤¥Ù¥ó¥È¥­¥ã¥×¥Á¥ã¡¼Ää»ß
+	//--ã‚¤ãƒ™ãƒ³ãƒˆã‚­ãƒ£ãƒ—ãƒãƒ£ãƒ¼åœæ­¢
 	function _removeEventHandle()
 	{
 		document.onmousemove = null;
@@ -207,7 +207,7 @@ function _plugin_datefield_dragLay( x, y)
 
 	/* ---------------------------------------------------------------------------------- */
 	
-	//¥á¥½¥Ã¥É¤òÄÉ²Ã
+	//ãƒ¡ã‚½ãƒƒãƒ‰ã‚’è¿½åŠ 
 	_plugin_datefield_dragLay.prototype.moveDivPos   = _moveDivPos;
 	_plugin_datefield_dragLay.prototype.mdown        = _mdown;
 	_plugin_datefield_dragLay.prototype.outputDivHTML= _outputDivHTML;
@@ -218,7 +218,7 @@ function _plugin_datefield_dragLay( x, y)
 	_plugin_datefield_dragLay.prototype.removeEventHandle  = _removeEventHandle;
 	/* ---------------------------------------------------------------------------------- */
 
-	// n4°Ê³°ÍÑ
+	// n4ä»¥å¤–ç”¨
 	this.div='<div  id="' + this.layerName + '" class="dragLays"\n'
 		  + '      onmousedown="clickElement=\''+ this.layerName
 		  +'\';_plugin_datefield_dragLay.mdown(event);return false"\n'
@@ -234,14 +234,14 @@ function _plugin_datefield_dragLay( x, y)
 	return null;
 }
 
-// Ãí°Õ: stdMonth ¤Ï 1·î¤¬0¡¢... 12·î¤Ï11 ¤Ç»ØÄê¤¹¤ë¤³¤È
+// æ³¨æ„: stdMonth ã¯ 1æœˆãŒ0ã€... 12æœˆã¯11 ã§æŒ‡å®šã™ã‚‹ã“ã¨
 function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, stdYear, stdMonth, stdDay, doSubmit, doReset)
 {
 
 	/********************************************************************
-	 * »ØÄê·Á¼°¤Ë±è¤Ã¤¿ÆüÉÕÊ¸»úÎó¤ÎºîÀ®
+	 * æŒ‡å®šå½¢å¼ã«æ²¿ã£ãŸæ—¥ä»˜æ–‡å­—åˆ—ã®ä½œæˆ
 	 *  Syntax : _dateWithFormat(dateFormatType , wrtYYYY , wrtMM , wrtDD )
-	 *  Îã     : _dateWithFormat('YYYY/MM/DD', 2003 , 10 , 3 )
+	 *  ä¾‹     : _dateWithFormat('YYYY/MM/DD', 2003 , 10 , 3 )
 	 * ------------------------------------------------------------------
 	 */
 	function _dateWithFormat(dateFormatType , wrtYYYY , wrtMM , wrtDD )
@@ -261,9 +261,9 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 	}
 
 	/********************************************************************
-	 * ¥«¥ì¥ó¥À¡¼¤ò¸Æ¤Ó½Ğ¤¹<input>¥Õ¥£¡¼¥ë¥ÉÊ¸»úÎó¤ÎºîÀ®
+	 * ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼ã‚’å‘¼ã³å‡ºã™<input>ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰æ–‡å­—åˆ—ã®ä½œæˆ
 	 *  Syntax : _getCallCalendarScript(rObj, rThis, tags, diff)
-	 *  Îã     : _getCallCalendarScript(obj, this , "now" , -1 )
+	 *  ä¾‹     : _getCallCalendarScript(obj, this , "now" , -1 )
 	 * ------------------------------------------------------------------
 	 */
 	function _getCallCalendarScript(rObj,rThis, tags, diff)
@@ -282,10 +282,10 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 	/* ---------------------------------------------------------------------- */
 
 	_plugin_datefield_dragLay.setDivVisibility( true );
-	_plugin_datefield_dragLay.removeEventHandle(); // ¥¤¥Ù¥ó¥È¥­¥ã¥×¥Á¥ã¡¼¥ê¥»¥Ã¥È
-	_plugin_datefield_dragLay.setEventHandle(); // ¥¤¥Ù¥ó¥È¥­¥ã¥×¥Á¥ã¡¼¥¹¥¿¡¼¥È
+	_plugin_datefield_dragLay.removeEventHandle(); // ã‚¤ãƒ™ãƒ³ãƒˆã‚­ãƒ£ãƒ—ãƒãƒ£ãƒ¼ãƒªã‚»ãƒƒãƒˆ
+	_plugin_datefield_dragLay.setEventHandle(); // ã‚¤ãƒ™ãƒ³ãƒˆã‚­ãƒ£ãƒ—ãƒãƒ£ãƒ¼ã‚¹ã‚¿ãƒ¼ãƒˆ
 
-	// ¸½ºß¤Î»ş´Ö¾ğÊó¤Î¼èÆÀ
+	// ç¾åœ¨ã®æ™‚é–“æƒ…å ±ã®å–å¾—
 	this.now =  new Date();
 	this.nowyear  = this.now.getFullYear();
 	this.nowmonth = this.now.getMonth() ;
@@ -296,12 +296,12 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 	if( isNaN(this.diffMonth) )	this.diffMonth = 0;
 	if( ! arguments[3] ) diffMonth = 0;
 
-	// ¥«¥ì¥ó¥ÀÉ½¼¨·î´ğ½àÆü¾ğÊó
+	// ã‚«ãƒ¬ãƒ³ãƒ€è¡¨ç¤ºæœˆåŸºæº–æ—¥æƒ…å ±
 	this.stdyear  = ( ! arguments[4] ) ? this.nowyear  : stdYear; 
 	this.stdmonth = ( ! arguments[5] ) ? this.nowmonth : stdMonth; 
 	this.stdday   = ( ! arguments[6] ) ? this.nowday   : stdDay;
 
-	// ¥«¥ì¥ó¥À¡¼¤Ç¤ÎÊÑ¹¹¤ÎÂ¨»şÈ¿±Ç¤ÎÍ­Ìµ(default: Â¨»şÈ¿±Ç)
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼ã§ã®å¤‰æ›´ã®å³æ™‚åæ˜ ã®æœ‰ç„¡(default: å³æ™‚åæ˜ )
 	this.doSubmit  = ( ! arguments[7] ) ? 0 : ( ( doSubmit == 1 ) ? 1 : 0 );
 
 	// doReset
@@ -325,11 +325,11 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 		break;
 	}
 
-	// ½µ¤ÎÀßÄê
-	if( browserLang.search(/ja/i) != -1 && "¤¢".length == 1 )
+	// é€±ã®è¨­å®š
+	if( browserLang.search(/ja/i) != -1 && "ã‚".length == 1 )
 	{
-		this.week = new Array('Æü','·î','²Ğ','¿å','ÌÚ','¶â','ÅÚ');
-		this.titleToday = 'º£Æü¡§';
+		this.week = new Array('æ—¥','æœˆ','ç«','æ°´','æœ¨','é‡‘','åœŸ');
+		this.titleToday = 'ä»Šæ—¥ï¼š';
 	}
 	else
 	{
@@ -337,17 +337,17 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 		this.titleToday = 'Today:';
 	}
 
-	// ¥«¥ì¥ó¥À¡¼¹½ÃÛÍÑHTML(¥Ø¥Ã¥À¡¼)
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼æ§‹ç¯‰ç”¨HTML(ãƒ˜ãƒƒãƒ€ãƒ¼)
 	_plugin_datefield_dspCalendar.headHTML = '  <form>\n'
 	  + '  <table border="0" width="140" class="datefield"> \n';
 
-	// ¥«¥ì¥ó¥À¡¼¹½ÃÛÍÑHTML(¥Õ¥Ã¥¿¡¼)
-	// ¥¹¥Æ¡¼¥¿¥¹¹Ô ÆüÉÕ¥¿¥¤¥×
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼æ§‹ç¯‰ç”¨HTML(ãƒ•ãƒƒã‚¿ãƒ¼)
+	// ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹è¡Œ æ—¥ä»˜ã‚¿ã‚¤ãƒ—
 	_plugin_datefield_dspCalendar.footHTML = '<tr>\n'
 	  + '  <td colspan="7" align="center" class="datefield-footer">\n'
 	  + '<b> ' + this.titleToday 
 	  
-	  // º£Æü¤ÎÆüÉÕ¤â¥ê¥ó¥¯°·¤¤¤Ë¤¹¤ë
+	  // ä»Šæ—¥ã®æ—¥ä»˜ã‚‚ãƒªãƒ³ã‚¯æ‰±ã„ã«ã™ã‚‹
 	  + '<a href="javascript:function lay_v(){ ' //"
 	  + 'document.' + obj.form.name + '.' + obj.name
 	  + '.value=('
@@ -386,31 +386,31 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 	  + '</table>\n'
 	  + '</form>\n';
 	
-	// ¥«¥ì¥ó¥À¡¼É½¼¨·î¾ğÊó¤Î¼èÆÀ¤È¥¿¥¤¥È¥ë¤ÎºîÀ®
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼è¡¨ç¤ºæœˆæƒ…å ±ã®å–å¾—ã¨ã‚¿ã‚¤ãƒˆãƒ«ã®ä½œæˆ
 	var dspYYYY = cldrDate.getFullYear();
 	var dspMM  = cldrDate.getMonth();
 	var tDspMM = dspMM+1;
 	tDspMM = ( tDspMM < 10 ) ? "0" + tDspMM : tDspMM ; 
 	var titleDspMonth = dspYYYY + '/' + tDspMM;
 	
-	// ¥«¥ì¥ó¥À¡¼¹½ÃÛÍÑHTML(¥Ø¥Ã¥ÀÉÕÍ¿)
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼æ§‹ç¯‰ç”¨HTML(ãƒ˜ãƒƒãƒ€ä»˜ä¸)
 	var cldrHTML = _plugin_datefield_dspCalendar.headHTML;
 
-	// ¥«¥ì¥ó¥À¡¼¹½ÃÛÍÑHTML(Æ°ÅªÊÑ¹¹ÉôÊ¬): Month
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼æ§‹ç¯‰ç”¨HTML(å‹•çš„å¤‰æ›´éƒ¨åˆ†): Month
 	cldrHTML += '<tr class="datefield-month">\n'
 	  + '<th colspan="7" align="center">\n';
 	
-	// Àè·î¤Ø¤Î¥Ü¥¿¥óÉ½¼¨	
+	// å…ˆæœˆã¸ã®ãƒœã‚¿ãƒ³è¡¨ç¤º	
 	cldrHTML += _getCallCalendarScript(obj,this,"&lt;&lt;", -1);
 	
 	cldrHTML += titleDspMonth + '\n';
 	
-	// ¼¡·î¤Ø¤Î¥Ü¥¿¥óÉ½¼¨	
+	// æ¬¡æœˆã¸ã®ãƒœã‚¿ãƒ³è¡¨ç¤º	
 	cldrHTML += _getCallCalendarScript(obj,this,"&gt;&gt;", 1);
 	
 	cldrHTML += ' </th>\n</tr>\n';
 	
-	// ¥«¥ì¥ó¥À¡¼¹½ÃÛÍÑHTML(Æ°ÅªÊÑ¹¹ÉôÊ¬): Week
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼æ§‹ç¯‰ç”¨HTML(å‹•çš„å¤‰æ›´éƒ¨åˆ†): Week
 	cldrHTML += ' <tr> \n';
 	for ( i = 0 ; i < 7 ; i++ )
 	{
@@ -419,7 +419,7 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 	cldrHTML += '  </tr>\n';
 	
 	// Date
-	//  - É½¼¨·î¤Î¥«¥ì¥ó¥À¡¼¤ÎºÇ½é¤ÎÆüÍËÆü¤Ë¤¢¤¿¤ëÆüÉÕ¤Î¼èÆÀ
+	//  - è¡¨ç¤ºæœˆã®ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼ã®æœ€åˆã®æ—¥æ›œæ—¥ã«ã‚ãŸã‚‹æ—¥ä»˜ã®å–å¾—
 	cldrDate.setDate( -(cldrDate.getDay()-1) );
 	var wrtDate = new Date(cldrDate.getFullYear(),cldrDate.getMonth(),cldrDate.getDate());
 	
@@ -431,8 +431,8 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 		
 		for( daycnt=0; daycnt < 7; daycnt++ )
 		{
-			// setTime ¤òÍÑ¤¤¤Æ´ğ½àÆü¤«¤é1ÆüÃ±°Ì¤Ë¤º¤é¤¹¡£
-			// setTime ¤Ç¼è°·¤¦Ã±°Ì¤Ï¥ß¥êÉÃÃ±°Ì(setDate()¤òº¹Ê¬¾ğÊó¤Ç¤Ï°·¤¨¤é¤ì¤Ê¤¤)
+			// setTime ã‚’ç”¨ã„ã¦åŸºæº–æ—¥ã‹ã‚‰1æ—¥å˜ä½ã«ãšã‚‰ã™ã€‚
+			// setTime ã§å–æ‰±ã†å˜ä½ã¯ãƒŸãƒªç§’å˜ä½(setDate()ã‚’å·®åˆ†æƒ…å ±ã§ã¯æ‰±ãˆã‚‰ã‚Œãªã„)
 			wrtDate.setTime(stdTime + (weekcnt*7 + daycnt) * (24*60*60*1000)); 
 			wrtDD   = wrtDate.getDate();
 			wrtMM   = wrtDate.getMonth();
@@ -475,10 +475,10 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 		cldrHTML += '</tr>\n';
 	}
 
-	// ¥«¥ì¥ó¥À¡¼¹½ÃÛÍÑHTML(¥Õ¥Ã¥¿ÉÕÍ¿)
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼æ§‹ç¯‰ç”¨HTML(ãƒ•ãƒƒã‚¿ä»˜ä¸)
 	cldrHTML += _plugin_datefield_dspCalendar.footHTML;
 		
-	_plugin_datefield_dragLay.outputDivHTML('');       //°ì»ş¥¯¥ê¥¢
+	_plugin_datefield_dragLay.outputDivHTML('');       //ä¸€æ™‚ã‚¯ãƒªã‚¢
 	_plugin_datefield_dragLay.outputDivHTML(cldrHTML);
 	
 	if( event !== null )

--- a/datefield.inc.php/datefield.js-subwin
+++ b/datefield.inc.php/datefield.js-subwin
@@ -14,8 +14,8 @@
  */
 
 // ===================================================================
-// Layer Version ÍÑ¥³¡¼¥É
-// DOM= 0 or 1 ¤Ï¤³¤Î¥¹¥¯¥ê¥×¥È¤Ç¤ÏÂĞ±ş³°¤È¤·¤Ş¤¹¡£
+// Layer Version ç”¨ã‚³ãƒ¼ãƒ‰
+// DOM= 0 or 1 ã¯ã“ã®ã‚¹ã‚¯ãƒªãƒ—ãƒˆã§ã¯å¯¾å¿œå¤–ã¨ã—ã¾ã™ã€‚
 // Functions for CrossBrowser-----------------------------------------
 // DOM: 1=NN4, 2=IE4, 3=IE5+, 4=NN6+, 0=Others
 DOM = document.all ? 
@@ -26,13 +26,13 @@ DOM = document.all ?
 isMOZ  = navigator.userAgent.indexOf('Gecko')!=-1 ? true : false;
 
 // ===================================================================
-// === UI¥³¥ó¥È¥í¡¼¥ëÉôÊ¬(Å¬µ¹½¤Àµ¤·¤Æ¤¯¤À¤µ¤¤) =====================
-// ¥«¥ì¥ó¥À½Ğ¸½°ÌÃÖ¤Î»ØÄê (ÆşÎÏ¥Æ¥­¥¹¥ÈÉôÊ¬¤«¤é¤ÎOffset)
+// === UIã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«éƒ¨åˆ†(é©å®œä¿®æ­£ã—ã¦ãã ã•ã„) =====================
+// ã‚«ãƒ¬ãƒ³ãƒ€å‡ºç¾ä½ç½®ã®æŒ‡å®š (å…¥åŠ›ãƒ†ã‚­ã‚¹ãƒˆéƒ¨åˆ†ã‹ã‚‰ã®Offset)
 
 _plugin_datefield_dspCalendar.offsetX =  50;
 _plugin_datefield_dspCalendar.offsetY = -30;
 
-// ¥«¥ì¥ó¥À¤ÎÂç¤­¤µ¤Î»ØÄê 
+// ã‚«ãƒ¬ãƒ³ãƒ€ã®å¤§ãã•ã®æŒ‡å®š 
 
 _plugin_datefield_dspCalendar.width  = 160;
 _plugin_datefield_dspCalendar.height = 250;
@@ -71,9 +71,9 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 	/* -------------------------------------------------------------------------------- */
 
 	 /********************************************************************
-	 * ¸Æ¤Ó½Ğ¤·¸µ¤Î checkbox ¤Î¥Á¥§¥Ã¥¯¤ò³°¤¹.
+	 * å‘¼ã³å‡ºã—å…ƒã® checkbox ã®ãƒã‚§ãƒƒã‚¯ã‚’å¤–ã™.
 	 *  Syntax : _makeCalledCheckboxFalse()
-	 *  Îã     : _makeCalledCheckboxFalse()
+	 *  ä¾‹     : _makeCalledCheckboxFalse()
 	 * ------------------------------------------------------------------
 	 */
 	function _makeCalledCheckboxFalse()
@@ -83,42 +83,42 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 	}
 
 	/********************************************************************
-	 * ´Ê°×ÆşÎÏÍÑ¥¦¥¤¥ó¥É¥¦¤ÎºîÀ®
+	 * ç°¡æ˜“å…¥åŠ›ç”¨ã‚¦ã‚¤ãƒ³ãƒ‰ã‚¦ã®ä½œæˆ
 	 *  Syntax : _plugin_datefield_mkSubWin(URL,winName,x,y,w,h)
-	 *  Îã     : _plugin_datefield_mkSubWin(winIndex,'test.htm','win0',100,200,150,300)
+	 *  ä¾‹     : _plugin_datefield_mkSubWin(winIndex,'test.htm','win0',100,200,150,300)
 	 * ------------------------------------------------------------------
 	 * from calendar.js Copyright(c)1999 Toshirou Takahashi tato@fureai.or.jp
 	 * Support http://www.fureai.or.jp/~tato/JS/BOOK/INDEX.HTM
 	 * 
-	 * ¾åµ­¤Î¥¹¥¯¥ê¥×¥È¤Ë´Ş¤Ş¤ì¤Æ¤¤¤ëÆ±´Ø¿ô¤ò°ìÉô½¤Àµ¡£-- 2003/11/03 jjyun
+	 * ä¸Šè¨˜ã®ã‚¹ã‚¯ãƒªãƒ—ãƒˆã«å«ã¾ã‚Œã¦ã„ã‚‹åŒé–¢æ•°ã‚’ä¸€éƒ¨ä¿®æ­£ã€‚-- 2003/11/03 jjyun
 	 * ------------------------------------------------------------------
 	 */
 	function _mkSubWin( URL, winName, x, y, w, h)
 	{
 	   	 var para = "" + 
-			" left="        + x  //[e4] ¥¦¥£¥ó¥É¥¦¤Î°ÌÃÖ(²èÌÌ¤Îº¸Ã¼¤«¤é¤Îµ÷Î¥)
- 			+ ",screenX="   + x  //[N4] left¤ÈÆ±¤¸¡£
-			+ ",top="       + y  //[e4] ¥¦¥£¥ó¥É¥¦¤Î°ÌÃÖ(²èÌÌ¤Î¾åÃ¼¤«¤é¤Îµ÷Î¥)
-			+ ",screenY="   + y  //[N4] top¤ÈÆ±¤¸¡£
-			+ ",height="    + h  //[e3/N2] ¥¦¥£¥ó¥É¥¦¤Î¹â¤µ.
-  			+ ",width="     + w  //[e3/N2] ¥¦¥£¥ó¥É¥¦¤Î²£Éı¡£
-			+ ",directories=no"  //[e3/N2] ¥æ¡¼¥¶ÀßÄê¥Ä¡¼¥ë¥Ğ¡¼¤ÎÉ½¼¨
-  			+ ",location=no"     //[e3/N2] ¾ì½ê¥Ä¡¼¥ë¥Ğ¡¼¤ÎÉ½¼¨
- 			+ ",menubar=no"      //[e3/N2] ¥á¥Ë¥å¡¼¥Ğ¡¼¤ÎÉ½¼¨
- 			+ ",resizable=yes"   //[e3/N2] ¥ê¥µ¥¤¥º¤ò²ÄÇ½¤Ë¤¹¤ë
-			+ ",status=no"       //[e3/N2] ¥¹¥Æ¡¼¥¿¥¹¥Ğ¡¼¤ÎÉ½¼¨
-			+ ",toolbar=no"      //[e3/N2] ¥Ä¡¼¥ë¥Ğ¡¼¤ÎÉ½¼¨
- 			+ ",scrollbars=no"   //[e3/N2] ¥¹¥¯¥í¡¼¥ë¥Ğ¡¼¤ÎÉ½¼¨
-  			+ ",dependent=yes";  //[N4] ¿Æ¥¦¥£¥ó¥É¥¦¤¬ÊÄ¤¸¤¿»ş¤Ë»Ò¥¦¥£¥ó¥É¥¦¤âÊÄ¤¸¤ë
+			" left="        + x  //[e4] ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä½ç½®(ç”»é¢ã®å·¦ç«¯ã‹ã‚‰ã®è·é›¢)
+ 			+ ",screenX="   + x  //[N4] leftã¨åŒã˜ã€‚
+			+ ",top="       + y  //[e4] ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ä½ç½®(ç”»é¢ã®ä¸Šç«¯ã‹ã‚‰ã®è·é›¢)
+			+ ",screenY="   + y  //[N4] topã¨åŒã˜ã€‚
+			+ ",height="    + h  //[e3/N2] ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®é«˜ã•.
+  			+ ",width="     + w  //[e3/N2] ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®æ¨ªå¹…ã€‚
+			+ ",directories=no"  //[e3/N2] ãƒ¦ãƒ¼ã‚¶è¨­å®šãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã®è¡¨ç¤º
+  			+ ",location=no"     //[e3/N2] å ´æ‰€ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã®è¡¨ç¤º
+ 			+ ",menubar=no"      //[e3/N2] ãƒ¡ãƒ‹ãƒ¥ãƒ¼ãƒãƒ¼ã®è¡¨ç¤º
+ 			+ ",resizable=yes"   //[e3/N2] ãƒªã‚µã‚¤ã‚ºã‚’å¯èƒ½ã«ã™ã‚‹
+			+ ",status=no"       //[e3/N2] ã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ãƒãƒ¼ã®è¡¨ç¤º
+			+ ",toolbar=no"      //[e3/N2] ãƒ„ãƒ¼ãƒ«ãƒãƒ¼ã®è¡¨ç¤º
+ 			+ ",scrollbars=no"   //[e3/N2] ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®è¡¨ç¤º
+  			+ ",dependent=yes";  //[N4] è¦ªã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãŒé–‰ã˜ãŸæ™‚ã«å­ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚‚é–‰ã˜ã‚‹
 
 		_plugin_datefield_dspCalendar.calendarWindow = window.open(URL,winName,para);
 		_plugin_datefield_dspCalendar.calendarWindow.focus();
 	}
 
 	/********************************************************************
-	 * »ØÄê·Á¼°¤Ë±è¤Ã¤¿ÆüÉÕÊ¸»úÎó¤ÎºîÀ®
+	 * æŒ‡å®šå½¢å¼ã«æ²¿ã£ãŸæ—¥ä»˜æ–‡å­—åˆ—ã®ä½œæˆ
 	 *  Syntax : _dateWithFormat(dateFormatType, wrtYYYY , wrtMM , wrtDD )
-	 *  Îã     : _dateWithFormat('YYYY/MM/DD', 2003 , 10 , 3 )
+	 *  ä¾‹     : _dateWithFormat('YYYY/MM/DD', 2003 , 10 , 3 )
 	 * ------------------------------------------------------------------
 	 */
 	function _dateWithFormat(dateFormatType, wrtYYYY, wrtMM, wrtDD)
@@ -138,9 +138,9 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 	}
 
 	 /********************************************************************
-	 * ¥«¥ì¥ó¥À¡¼¤ò¸Æ¤Ó½Ğ¤¹<input>¥Õ¥£¡¼¥ë¥ÉÊ¸»úÎó¤ÎºîÀ®
+	 * ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼ã‚’å‘¼ã³å‡ºã™<input>ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰æ–‡å­—åˆ—ã®ä½œæˆ
 	 *  Syntax : _getCallCalendarScript(rObj, rThis, tags, diff)
-	 *  Îã     : _getCallCalendarScript(obj, this , "now" , -1 )
+	 *  ä¾‹     : _getCallCalendarScript(obj, this , "now" , -1 )
 	 * ------------------------------------------------------------------
 	 */
 	function _getCallCalendarScript(rObj,rThis, tags, diff){
@@ -196,7 +196,7 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 			break;
 		}
 		
-		//- ½µ¤ÎÀßÄê
+		//- é€±ã®è¨­å®š
 		this.week = new Array( 'Sn','Mn','Tu','Wd','Th','Fr','St' );
 		this.titleToday = 'Today :';
 
@@ -247,16 +247,16 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 
 	cldrHTML += '<tr class="datefield-month" > \n' + '<th colspan="7" align="center">\n';
 	
-	// Àè·î¤Ø¤Î¥Ü¥¿¥óÉ½¼¨
+	// å…ˆæœˆã¸ã®ãƒœã‚¿ãƒ³è¡¨ç¤º
 	cldrHTML += _getCallCalendarScript(obj,this,"&lt;&lt;", -1);
 	cldrHTML += titleDspMonth + '\n';
 	
-	// ¼¡·î¤Ø¤Î¥Ü¥¿¥óÉ½¼¨
+	// æ¬¡æœˆã¸ã®ãƒœã‚¿ãƒ³è¡¨ç¤º
 	cldrHTML += _getCallCalendarScript(obj,this,"&gt;&gt;", 1);
 
 	cldrHTML += ' </th>\n</tr>\n';
 	
-	// ¥«¥ì¥ó¥À¡¼¹½ÃÛÍÑHTML(Æ°ÅªÊÑ¹¹ÉôÊ¬) : Week
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼æ§‹ç¯‰ç”¨HTML(å‹•çš„å¤‰æ›´éƒ¨åˆ†) : Week
 	cldrHTML += ' <tr> \n';
 	for (i=0;i<7;i++){
 	  cldrHTML += '    <td class="datefield-week" >';
@@ -264,8 +264,8 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 	}
 	cldrHTML += '  </tr>\n';
 	
-	// ¥«¥ì¥ó¥À¡¼¹½ÃÛÍÑHTML(Æ°ÅªÊÑ¹¹ÉôÊ¬) : Date
-	//  - É½¼¨·î¤Î¥«¥ì¥ó¥À¡¼¤ÎºÇ½é¤ÎÆüÍËÆü¤Ë¤¢¤¿¤ëÆüÉÕ¤Î¼èÆÀ
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼æ§‹ç¯‰ç”¨HTML(å‹•çš„å¤‰æ›´éƒ¨åˆ†) : Date
+	//  - è¡¨ç¤ºæœˆã®ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼ã®æœ€åˆã®æ—¥æ›œæ—¥ã«ã‚ãŸã‚‹æ—¥ä»˜ã®å–å¾—
 	cldrDate.setDate( -(cldrDate.getDay()-1) );
 	var wrtDate = new Date(cldrDate.getFullYear(),cldrDate.getMonth(),cldrDate.getDate());
 	
@@ -277,8 +277,8 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 
 		for( daycnt=0; daycnt < 7; daycnt++ )
 		{
-			// setTime ¤òÍÑ¤¤¤Æ´ğ½àÆü¤«¤é1ÆüÃ±°Ì¤Ë¤º¤é¤¹¡£
-			// SETTIME ¤Ç¼è°·¤¦Ã±°Ì¤Ï¥ß¥êÉÃÃ±°Ì(setDate()¤òº¹Ê¬¾ğÊó¤Ç¤Ï°·¤¨¤é¤ì¤Ê¤¤)
+			// setTime ã‚’ç”¨ã„ã¦åŸºæº–æ—¥ã‹ã‚‰1æ—¥å˜ä½ã«ãšã‚‰ã™ã€‚
+			// SETTIME ã§å–æ‰±ã†å˜ä½ã¯ãƒŸãƒªç§’å˜ä½(setDate()ã‚’å·®åˆ†æƒ…å ±ã§ã¯æ‰±ãˆã‚‰ã‚Œãªã„)
 			wrtDate.setTime(stdTime + (weekcnt*7 + daycnt) * (24*60*60*1000)); 
 			wrtDD   = wrtDate.getDate();
 			wrtMM   = wrtDate.getMonth();
@@ -320,7 +320,7 @@ function _plugin_datefield_dspCalendar(obj, event, dateFormatType, diffMonth, st
 		cldrHTML += '</tr>\n';
 	}
 	
-	// ¥«¥ì¥ó¥À¡¼¹½ÃÛÍÑHTML(¥Õ¥Ã¥¿ÉÕÍ¿)
+	// ã‚«ãƒ¬ãƒ³ãƒ€ãƒ¼æ§‹ç¯‰ç”¨HTML(ãƒ•ãƒƒã‚¿ä»˜ä¸)
 	cldrHTML += _plugin_datefield_dspCalendar.footHTML;
 	
 	_plugin_datefield_dspCalendar.calendarWindow.document.charset="EUC-JP";

--- a/linkvote.inc.php/linkvote.inc.php
+++ b/linkvote.inc.php/linkvote.inc.php
@@ -16,7 +16,7 @@
  * 
  */
 
-// ¥ê¥ó¥¯¤òÊÌÁë¤Ç³«¤¯.
+// ãƒªãƒ³ã‚¯ã‚’åˆ¥çª“ã§é–‹ã.
 define('LINKVOTE_OPEN_LINK_WITH_ANOTHER_WINDOW', false);
 
 function plugin_linkvote_init()
@@ -28,11 +28,11 @@ function plugin_linkvote_init()
 			'arg_nolabel'     => 'nolabel',
 			'arg_notitle'     => 'notitle',
 			'title_error' => 'Error in linkvote',
-			'no_page_error' => '$1 ¤Î¥Ú¡¼¥¸¤ÏÂ¸ºß¤·¤Ş¤»¤ó',
-			'update_failed' => 'ÅêÉ¼¼ºÇÔ¡§$1¤Ë¤ª¤¤¤ÆÅêÉ¼Àè¤¬Ìµ¤¤¤«¹àÌÜ¤¬¹çÃ×¤·¤Ş¤»¤ó¤Ç¤·¤¿¡£',
-			'body_error' => '¤¢¤ë¤Ù¤­°ú¿ô¤¬ÅÏ¤µ¤ì¤Æ¤¤¤Ê¤¤¤«¡¢°ú¿ô¤Ë¥¨¥é¡¼¤¬¤¢¤ê¤Ş¤¹¡£',
-			'msg_collided'  => '<h3>¤¢¤Ê¤¿¤¬ÅêÉ¼¤·¤Æ¤¤¤ë´Ö¤Ë¡¢Â¾¤Î¿Í¤¬Æ±¤¸¥Ú¡¼¥¸¤ÎÆâÍÆ¤ò¹¹¿·¤·¤Æ¤·¤Ş¤Ã¤¿¤è¤¦¤Ç¤¹¡£<br />½¾¤Ã¤Æ¡¢ÅêÉ¼¤¹¤ë°ÌÃÖ¤ò´Ö°ã¤¨¤ë²ÄÇ½À­¤¬¤¢¤ê¤Ş¤¹¡£<br /><br />
-¤¢¤Ê¤¿¤Î¹¹¿·¤òÌµ¸ú¤Ë¤·¤Ş¤·¤¿¡£Á°¤Î¥Ú¡¼¥¸¤ò¥ê¥í¡¼¥É¤·¤Æ¤ä¤êÄ¾¤·¤Æ¤¯¤À¤µ¤¤¡£</h3>'
+			'no_page_error' => '$1 ã®ãƒšãƒ¼ã‚¸ã¯å­˜åœ¨ã—ã¾ã›ã‚“',
+			'update_failed' => 'æŠ•ç¥¨å¤±æ•—ï¼š$1ã«ãŠã„ã¦æŠ•ç¥¨å…ˆãŒç„¡ã„ã‹é …ç›®ãŒåˆè‡´ã—ã¾ã›ã‚“ã§ã—ãŸã€‚',
+			'body_error' => 'ã‚ã‚‹ã¹ãå¼•æ•°ãŒæ¸¡ã•ã‚Œã¦ã„ãªã„ã‹ã€å¼•æ•°ã«ã‚¨ãƒ©ãƒ¼ãŒã‚ã‚Šã¾ã™ã€‚',
+			'msg_collided'  => '<h3>ã‚ãªãŸãŒæŠ•ç¥¨ã—ã¦ã„ã‚‹é–“ã«ã€ä»–ã®äººãŒåŒã˜ãƒšãƒ¼ã‚¸ã®å†…å®¹ã‚’æ›´æ–°ã—ã¦ã—ã¾ã£ãŸã‚ˆã†ã§ã™ã€‚<br />å¾“ã£ã¦ã€æŠ•ç¥¨ã™ã‚‹ä½ç½®ã‚’é–“é•ãˆã‚‹å¯èƒ½æ€§ãŒã‚ã‚Šã¾ã™ã€‚<br /><br />
+ã‚ãªãŸã®æ›´æ–°ã‚’ç„¡åŠ¹ã«ã—ã¾ã—ãŸã€‚å‰ã®ãƒšãƒ¼ã‚¸ã‚’ãƒªãƒ­ãƒ¼ãƒ‰ã—ã¦ã‚„ã‚Šç›´ã—ã¦ãã ã•ã„ã€‚</h3>'
 
 		),
 	);
@@ -96,7 +96,7 @@ function plugin_linkvote_inline()
 	$str_bunner = '';
 
 	$args = func_get_args();
-	array_pop($args); // {}Æâ¤ÎÍ×ÁÇ¤Îºï½ü
+	array_pop($args); // {}å†…ã®è¦ç´ ã®å‰Šé™¤
 	$page = $vars['page'];
 	if (!array_key_exists($page,$numbers))	$numbers[$page] = 0;
 	$vote_inno = $numbers[$page]++;
@@ -442,16 +442,16 @@ function plugin_linkvote_action_block($vote_no)
 // -- linkvote.inc.php --
 // Update Logs - Modified by jjyun. (2004/02/22 - 2004/12/10)
 //  v0.5 2006/04/02 modified by jjyun.
-//    ¥ê¥ó¥¯Àè¤òÊÌÁë¤ÇÉ½¼¨¤µ¤»¤ë¥Õ¥é¥°(LINKVOTE_OPEN_LINK_WITH_ANOTHER_WINDOW)¤òÄÉ²Ã.
+//    ãƒªãƒ³ã‚¯å…ˆã‚’åˆ¥çª“ã§è¡¨ç¤ºã•ã›ã‚‹ãƒ•ãƒ©ã‚°(LINKVOTE_OPEN_LINK_WITH_ANOTHER_WINDOW)ã‚’è¿½åŠ .
 //  v0.4 2004/12/10 modified by jjyun.
-//    ÆâÉô¥³¡¼¥É¤Î½¤Àµ(ÊÑ¹¹²Õ½ê plugin_linkvote_inline(), plugin_linkvote_address() )
+//    å†…éƒ¨ã‚³ãƒ¼ãƒ‰ã®ä¿®æ­£(å¤‰æ›´ç®‡æ‰€ plugin_linkvote_inline(), plugin_linkvote_address() )
 //  v0.3 2004/09/05 modified by jjyun.
-//    ¥ê¥ó¥¯Àè¤ÎÉ½µ­¤È¤·¤Æ²èÁü¥Õ¥¡¥¤¥ë¤ò»ØÄê¤Ç¤­¤ë¤è¤¦¤Ë¤¹¤ë
+//    ãƒªãƒ³ã‚¯å…ˆã®è¡¨è¨˜ã¨ã—ã¦ç”»åƒãƒ•ã‚¡ã‚¤ãƒ«ã‚’æŒ‡å®šã§ãã‚‹ã‚ˆã†ã«ã™ã‚‹
 //  v0.2 2004/08/13 modified by jjyun.
-//    ÆâÉô¥³¡¼¥É¤Î½¤Àµ($post,$get ¤òÍÑ¤¤¤Æ¤¤¤ëÉôÊ¬¤òºï½ü)
+//    å†…éƒ¨ã‚³ãƒ¼ãƒ‰ã®ä¿®æ­£($post,$get ã‚’ç”¨ã„ã¦ã„ã‚‹éƒ¨åˆ†ã‚’å‰Šé™¤)
 //  v0.1 2004/07/28 create by jjyun. based on vote2.inc.php, v 0.12 
 //
-// (vote2.inc.php ¤è¤ê)
+// (vote2.inc.php ã‚ˆã‚Š)
 //   vote2.inc.php, v 0.12 2003/10/05 17:55:04 sha 
 //   based on vote.inc.php v1.14
 //

--- a/listbox3.inc.php/listbox3.inc.php
+++ b/listbox3.inc.php/listbox3.inc.php
@@ -10,12 +10,12 @@
 // License: GPL v2 or (at your option) any later version
 //
 
-// ½¤Àµ¸å¤Î¥ê¥í¡¼¥É»ş¤Ë¡¢ÊÔ½¸²Õ½ê¤ØÉ½¼¨²Õ½ê¤ò°Ü¤¹
-// Í­¸ú¤Ë¤¹¤ë¾ì¹ç¤Ë¤Ï¡¢TRUE , Ìµ¸ú¤Ë¤¹¤ë¾ì¹ç¤Ë¤Ï FALSE ¤ò»ØÄê
+// ä¿®æ­£å¾Œã®ãƒªãƒ­ãƒ¼ãƒ‰æ™‚ã«ã€ç·¨é›†ç®‡æ‰€ã¸è¡¨ç¤ºç®‡æ‰€ã‚’ç§»ã™
+// æœ‰åŠ¹ã«ã™ã‚‹å ´åˆã«ã¯ã€TRUE , ç„¡åŠ¹ã«ã™ã‚‹å ´åˆã«ã¯ FALSE ã‚’æŒ‡å®š
 define('LISTBOX3_JUMP_TO_MODIFIED_PLACE',FALSE); // TRUE or FALSE
-// ¥ê¥¹¥È¥¢¥¤¥Æ¥à¤Ë½ñ¼°¤òÅ¬ÍÑ¤¹¤ë(¿§»ØÄê¤Î¤ß)
+// ãƒªã‚¹ãƒˆã‚¢ã‚¤ãƒ†ãƒ ã«æ›¸å¼ã‚’é©ç”¨ã™ã‚‹(è‰²æŒ‡å®šã®ã¿)
 define('LISTBOX3_APPLY_FORMAT',TRUE); // TRUE or FALSE
-// ¥â¡¼¥ÉÊÑ¹¹¤òÅ¬ÍÑ¤¹¤ë
+// ãƒ¢ãƒ¼ãƒ‰å¤‰æ›´ã‚’é©ç”¨ã™ã‚‹
 define('LISTBOX3_APPLY_MODECHANGE',TRUE); // TRUE or FALSE
 
 function plugin_listbox3_init()
@@ -50,7 +50,7 @@ function plugin_listbox3_action()
 				$opt = $match[1];
 				if($vars['number'] == $number++)
 				{
-					//¥¿¡¼¥²¥Ã¥È¤Î¥×¥é¥°¥¤¥óÉôÊ¬
+					//ã‚¿ãƒ¼ã‚²ãƒƒãƒˆã®ãƒ—ãƒ©ã‚°ã‚¤ãƒ³éƒ¨åˆ†
 					$opt = preg_replace('/[^,]*/', $vars['select'], $opt, 1);
 				}
 				$line .= "#listbox3($opt)" . $paddata[$i+1];
@@ -68,14 +68,14 @@ function plugin_listbox3_action()
 	return array('msg' => '', 'body' => '');
 }
 
-// headerÀë¸À¤ÎÃæ¤Ç°Ê²¼¤Î£²¤Ä¤ÎÄêµÁ¤ò¹Ô¤¦
-// ¡¦Javascipt¤òÍÑ¤¤¤ë¤³¤È¡¢
-// ¡¦XHTML1.0 Transitional Mode¤Ç¤ÎÆ°ºî¡Ê<form>¥¿¥°¤ËnameÂ°À­¤òÍÑ¤¤¤ë¡Ë
+// headerå®£è¨€ã®ä¸­ã§ä»¥ä¸‹ã®ï¼’ã¤ã®å®šç¾©ã‚’è¡Œã†
+// ãƒ»Javasciptã‚’ç”¨ã„ã‚‹ã“ã¨ã€
+// ãƒ»XHTML1.0 Transitional Modeã§ã®å‹•ä½œï¼ˆ<form>ã‚¿ã‚°ã«nameå±æ€§ã‚’ç”¨ã„ã‚‹ï¼‰
 function plugin_listbox3_headDeclaration()
 {
 	global $pkwk_dtd, $javascript,$head_tags;
 
-	// Javascipt¤òÍÑ¤¤¤ë¤³¤È¡¢<form>¥¿¥°¤ËnameÂ°À­¤òÍÑ¤¤¤ë¤³¤È¤òÄÌÃÎ¤¹¤ë
+	// Javasciptã‚’ç”¨ã„ã‚‹ã“ã¨ã€<form>ã‚¿ã‚°ã«nameå±æ€§ã‚’ç”¨ã„ã‚‹ã“ã¨ã‚’é€šçŸ¥ã™ã‚‹
 	if( PKWK_ALLOW_JAVASCRIPT && LISTBOX3_APPLY_MODECHANGE )
 	{
 		// XHTML 1.0 Transitional
@@ -84,11 +84,11 @@ function plugin_listbox3_headDeclaration()
 			$pkwk_dtd = PKWK_DTD_XHTML_1_0_TRANSITIONAL;
 		}
     
-		// <head> ¥¿¥°Æâ¤Ø¤Î <meta>Àë¸À¤ÎÄÉ²Ã
+		// <head> ã‚¿ã‚°å†…ã¸ã® <meta>å®£è¨€ã®è¿½åŠ 
 		$javascript = TRUE;
 	}
 
-	// <head> ¥¿¥°Æâ¤Ø¤Î <meta>Àë¸À¤ÎÄÉ²Ã
+	// <head> ã‚¿ã‚°å†…ã¸ã® <meta>å®£è¨€ã®è¿½åŠ 
 	$meta_str =
 		" <meta http-equiv=\"content-script-type\" content=\"text/javascript\" /> ";
 	if(! in_array($meta_str, $head_tags) )
@@ -103,7 +103,7 @@ function plugin_listbox3_convert()
 
 	$number = plugin_listbox3_getNumber();
 
-	// header ¤ÎÀë¸À
+	// header ã®å®£è¨€
 	if( $number == 0 )
 	{
 		plugin_listbox3_headDeclaration();
@@ -139,7 +139,7 @@ function plugin_listbox3_getBody($number, $value, $template, $fieldname)
 	$page_enc = htmlspecialchars($vars['page']);
 	$script_enc = htmlspecialchars($script);
 	
-	// listbox3 ÍÑ¤Î<script>¥¿¥°¤ÎÁŞÆş ( for LISTBOX3_APPLY_MODECHANGE )
+	// listbox3 ç”¨ã®<script>ã‚¿ã‚°ã®æŒ¿å…¥ ( for LISTBOX3_APPLY_MODECHANGE )
 	$extrascript = (PKWK_ALLOW_JAVASCRIPT && LISTBOX3_APPLY_MODECHANGE && $number == 0) ? plugin_listbox3_getScript() : '';
 
 	$options_html = plugin_listbox3_getOptions($value, $template, $fieldname);
@@ -226,7 +226,7 @@ function plugin_listbox3_getOptions($value, $config_name, $field_name)
   
 	if( $isSelect == 0 )
 	{
-		$options_html = "<option value='¡Ä' selected='selected'>¡Ä</option>" . $options_html;
+		$options_html = "<option value='â€¦' selected='selected'>â€¦</option>" . $options_html;
 	}
 	return $options_html;
 }

--- a/memox.inc.php/memox.inc.php
+++ b/memox.inc.php/memox.inc.php
@@ -1,25 +1,25 @@
 <?php
 // $Id: memox.inc.php,v 0.7 2006/05/02 00:01:11 jjyun Exp $
 /**
- * PukiWiki •·•‚≥»ƒ••◊•È•∞•§•Û(memo eXtented plugin)
+ * PukiWiki „É°„É¢Êã°Âºµ„Éó„É©„Ç∞„Ç§„É≥(memo eXtented plugin)
  * (C) 2004, jjyun. http://www2.g-com.ne.jp/~jjyun/twilight-breeze/pukiwiki.php
  *
- * License: PukiWiki À‹¬Œ§»∆±§∏§Ø GNU General Public License (GPL) §«§π
+ * License: PukiWiki Êú¨‰Ωì„Å®Âêå„Åò„Åè GNU General Public License (GPL) „Åß„Åô
  * http://www.gnu.org/licenses/gpl.txt
  *
  * Description:
  *  #memox([column],[rows],[title],DELIM-STR,[contents])
  * 
- * §≥§Œ•≥°º•…§Œ¿‚Ã¿§œ°¢PukiWikiÀ‹¬Œ§À∆±∫≠§µ§Ï§∆§§§Î memo.inc.php,v 1.11 §À
- * •´•È•‡,π‘øÙ,ππø∑•‹•ø•Û§Œ•È•Ÿ•Î§Ú¿ﬂ√÷ª˛§À —ππ§«§≠§Î§Ë§¶Ω§¿µ§Ú≤√§®§ø§‚§Œ§«§π°£
+ * „Åì„ÅÆ„Ç≥„Éº„Éâ„ÅÆË™¨Êòé„ÅØ„ÄÅPukiWikiÊú¨‰Ωì„Å´ÂêåÊ¢±„Åï„Çå„Å¶„ÅÑ„Çã memo.inc.php,v 1.11 „Å´
+ * „Ç´„É©„É†,Ë°åÊï∞,Êõ¥Êñ∞„Éú„Çø„É≥„ÅÆ„É©„Éô„É´„ÇíË®≠ÁΩÆÊôÇ„Å´Â§âÊõ¥„Åß„Åç„Çã„Çà„ÅÜ‰øÆÊ≠£„ÇíÂä†„Åà„Åü„ÇÇ„ÅÆ„Åß„Åô„ÄÇ
  */
 
 /////////////////////////////////////////////////
-// •∆•≠•π•»•®•Í•¢§Œ•´•È•‡øÙ
+// „ÉÜ„Ç≠„Çπ„Éà„Ç®„É™„Ç¢„ÅÆ„Ç´„É©„É†Êï∞
 define('MEMOX_DEFAULT_COLS', 80);
-// •∆•≠•π•»•®•Í•¢§Œπ‘øÙ
+// „ÉÜ„Ç≠„Çπ„Éà„Ç®„É™„Ç¢„ÅÆË°åÊï∞
 define('MEMOX_DEFAULT_ROWS', 5);
-// •«•Í•ﬂ•ø(DELIM-STR)§Œ¿ﬂƒÍ
+// „Éá„É™„Éü„Çø(DELIM-STR)„ÅÆË®≠ÂÆö
 define('MEMOX_DELIM_STR',  '<DELIM>');
 
 /////////////////////////////////////////////////
@@ -39,7 +39,7 @@ function plugin_memox_init()
 function plugin_memox_init_ja()
 {
     $msg = array(
-                 '_btn_memox_update' => "ππø∑",
+                 '_btn_memox_update' => "Êõ¥Êñ∞",
                  );
     return $msg;
 }
@@ -80,7 +80,7 @@ function plugin_memox_action()
             continue;
         }
 
-        // •÷•Ì•√•Ø•◊•È•∞•§•Û§ŒæÏπÁ§œ°¢…Ω§Œ√Ê§ŒÕ¯Õ—§‚πÕŒ∏§π§Î§≥§»
+        // „Éñ„É≠„ÉÉ„ÇØ„Éó„É©„Ç∞„Ç§„É≥„ÅÆÂ†¥Âêà„ÅØ„ÄÅË°®„ÅÆ‰∏≠„ÅÆÂà©Áî®„ÇÇËÄÉÊÖÆ„Åô„Çã„Åì„Å®
         if(preg_match_all('/(?:#memox\(([^\)]*)\))/', $line,$matches, PREG_SET_ORDER))
         {
             $paddata = preg_split('/#memox\([^\)]*\)/', $line);
@@ -88,7 +88,7 @@ function plugin_memox_action()
             foreach($matches as $i => $match) 
             {
                 if ($vars['memox_no'] == $memox_no++ ) {
-                    // •ø°º•≤•√•»§Œ•◊•È•∞•§•Û…Ù ¨
+                    // „Çø„Éº„Ç≤„ÉÉ„Éà„ÅÆ„Éó„É©„Ç∞„Ç§„É≥ÈÉ®ÂàÜ
                     $opt = "$s_cols,$s_rows,$s_blabel";
                     $opt .= ",". MEMOX_DELIM_STR . ",$memo_body";
 

--- a/pages2csv.inc.php/pages2csv.inc.php
+++ b/pages2csv.inc.php/pages2csv.inc.php
@@ -5,7 +5,7 @@
 // $Id: pages2csv.inc.php,v 1.5 2006/07/21 21:31:27 jjyun Exp $
 // 
 /////////////////////////////////////////////////
-// ´ÉÍı¼Ô¤À¤±¤¬ÅºÉÕ¥Õ¥¡¥¤¥ë¤ò¥¢¥Ã¥×¥í¡¼¥É¤Ç¤­¤ë¤è¤¦¤Ë¤¹¤ë
+// ç®¡ç†è€…ã ã‘ãŒæ·»ä»˜ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ã§ãã‚‹ã‚ˆã†ã«ã™ã‚‹
 define('PLUGIN_PAGES2CSV_UPLOAD_ADMIN_ONLY',FALSE); // FALSE or TRUE
 /////////////////////////////////////////////////
 
@@ -21,11 +21,11 @@ function plugin_pages2csv_init()
   
     $messages = array(
         '_pages2csv_messages' => array(
-            'btn_submit' => '¼Â¹Ô',
-            'title_text' => 'CSV¥Õ¥¡¥¤¥ëÀ¸À®¡§',
-            'err_create_tmpfile' => '°ì»ş¥Õ¥¡¥¤¥ë¤ÎºîÀ®¤Ë¼ºÇÔ¡§',
-            'err_write_tmpfile' => '°ì»ş¥Õ¥¡¥¤¥ë¤Ø¤Î½ñ¤­¹ş¤ß¤Ë¼ºÇÔ¡§',
-            'err_rename_tmpfile' => 'ÅºÉÕ¥Õ¥¡¥¤¥ë¤Ø¤ÎÌ¾¾ÎÊÑ¹¹¤Ë¼ºÇÔ¡§',
+            'btn_submit' => 'å®Ÿè¡Œ',
+            'title_text' => 'CSVãƒ•ã‚¡ã‚¤ãƒ«ç”Ÿæˆï¼š',
+            'err_create_tmpfile' => 'ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆã«å¤±æ•—ï¼š',
+            'err_write_tmpfile' => 'ä¸€æ™‚ãƒ•ã‚¡ã‚¤ãƒ«ã¸ã®æ›¸ãè¾¼ã¿ã«å¤±æ•—ï¼š',
+            'err_rename_tmpfile' => 'æ·»ä»˜ãƒ•ã‚¡ã‚¤ãƒ«ã¸ã®åç§°å¤‰æ›´ã«å¤±æ•—ï¼š',
             ),
         );
     set_plugin_messages($messages);
@@ -50,7 +50,7 @@ function plugin_pages2csv_convert()
     if (!array_key_exists($page,$numbers)) $numbers[$page] = 0;
     $pages2csv_no = $numbers[$page]++;
     
-    // °ú¿ô¤Î³ÎÇ§¡¦¼èÆÀ
+    // å¼•æ•°ã®ç¢ºèªãƒ»å–å¾—
     if (func_num_args())
     {
         $args = func_get_args();
@@ -102,8 +102,8 @@ function plugin_pages2csv_convert()
     $s_script = htmlspecialchars($script);
     
     $pass = '';
-    // attach.inc.php ¤Ç ¥¢¥Ã¥×¥í¡¼¥É/ºï½ü»ş¤Ë¥Ñ¥¹¥ï¡¼¥É¤òÍ×µá¤¹¤ëÀßÄê¤Ç¤¢¤Ã¤¿¾ì¹ç¤«
-    // ¤â¤·¤¯¤Ï¡¢CSV¥Õ¥¡¥¤¥ë¤ÎºîÀ®¤ò´ÉÍı¼Ô¤À¤±¤¬¹Ô¤¨¤ë¤è¤¦¤Ë¤·¤¿¾ì¹ç
+    // attach.inc.php ã§ ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰/å‰Šé™¤æ™‚ã«ãƒ‘ã‚¹ãƒ¯ãƒ¼ãƒ‰ã‚’è¦æ±‚ã™ã‚‹è¨­å®šã§ã‚ã£ãŸå ´åˆã‹
+    // ã‚‚ã—ãã¯ã€CSVãƒ•ã‚¡ã‚¤ãƒ«ã®ä½œæˆã‚’ç®¡ç†è€…ã ã‘ãŒè¡Œãˆã‚‹ã‚ˆã†ã«ã—ãŸå ´åˆ
     
     if ( PLUGIN_ATTACH_PASSWORD_REQUIRE or PLUGIN_PAGES2CSV_UPLOAD_ADMIN_ONLY)
     {
@@ -144,16 +144,16 @@ function plugin_pages2csv_action()
     global $vars;
     global $_attach_messages;
     
-    // ÍøÍÑ¤¹¤ë¥×¥é¥°¥¤¥ó¤ÎÂ¸ºß¥Á¥§¥Ã¥¯
+    // åˆ©ç”¨ã™ã‚‹ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
     if ( !function_exists('pkwk_login') )
     {
         return array('result'=>FALSE,'msg'=>"pkwk_login function is not found (in func.php).");
     }
 
-    // $vars['refer'] : Åö³º¤Îplugin ¤òÀßÃÖ¤·¤¿¥Ú¡¼¥¸
-    // $vars['s_page']  : ¥ê¥¹¥ÈÉ½¼¨¤¹¤ëtracker¤Î¥Ú¡¼¥¸¤Î³ÊÇ¼¾ì½ê
-    // ¥Ú¡¼¥¸Ì¾¤¬ NULL ¤Ç¤¢¤ë¾ì¹ç¤ÏÂ¸ºß¤·¤Ê¤¤¤ÈÁÛÄê
-    // ¤Ş¤¿ $pass ¤Ï ¤¢¤¯¤Ş¤Ç¥æ¡¼¥¶Â¦¤«¤é¤Î¥Ñ¥¹¥ï¡¼¥É¥Õ¥ì¡¼¥º¤òÉ½¤¹¤³¤È¤È¤¹¤ë¡£
+    // $vars['refer'] : å½“è©²ã®plugin ã‚’è¨­ç½®ã—ãŸãƒšãƒ¼ã‚¸
+    // $vars['s_page']  : ãƒªã‚¹ãƒˆè¡¨ç¤ºã™ã‚‹trackerã®ãƒšãƒ¼ã‚¸ã®æ ¼ç´å ´æ‰€
+    // ãƒšãƒ¼ã‚¸åãŒ NULL ã§ã‚ã‚‹å ´åˆã¯å­˜åœ¨ã—ãªã„ã¨æƒ³å®š
+    // ã¾ãŸ $pass ã¯ ã‚ãã¾ã§ãƒ¦ãƒ¼ã‚¶å´ã‹ã‚‰ã®ãƒ‘ã‚¹ãƒ¯ãƒ¼ãƒ‰ãƒ•ãƒ¬ãƒ¼ã‚ºã‚’è¡¨ã™ã“ã¨ã¨ã™ã‚‹ã€‚
     $s_page = array_key_exists('s_page',$vars) ? htmlspecialchars($vars['s_page']) : NULL;
     $refer = array_key_exists('refer',$vars) ? htmlspecialchars($vars['refer']) : NULL;
     $pass = array_key_exists('pass',$vars) ? htmlspecialchars($vars['pass']) : NULL;
@@ -169,8 +169,8 @@ function plugin_pages2csv_action()
     }
     else
     {
-        check_editable($refer);  // ÅºÉÕÀè¤Î¥Ú¡¼¥¸¤¬½ñ¤­¹ş¤ß²ÄÇ½¤«¡©
-        check_readable($s_page); // »²¾ÈÀè¤Î¥Ú¡¼¥¸¤¬ÆÉ¤ß¹ş¤ß²ÄÇ½¤«¡©
+        check_editable($refer);  // æ·»ä»˜å…ˆã®ãƒšãƒ¼ã‚¸ãŒæ›¸ãè¾¼ã¿å¯èƒ½ã‹ï¼Ÿ
+        check_readable($s_page); // å‚ç…§å…ˆã®ãƒšãƒ¼ã‚¸ãŒèª­ã¿è¾¼ã¿å¯èƒ½ã‹ï¼Ÿ
     }
     
     if (PLUGIN_PAGES2CSV_UPLOAD_ADMIN_ONLY and ($pass === NULL or ! pkwk_login($pass) ))
@@ -186,29 +186,29 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
 {
     global $_attach_messages, $_pages2csv_messages;
 
-    // ÍøÍÑ¤¹¤ë¥×¥é¥°¥¤¥ó¤ÎÂ¸ºß¥Á¥§¥Ã¥¯
+    // åˆ©ç”¨ã™ã‚‹ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®å­˜åœ¨ãƒã‚§ãƒƒã‚¯
     if (!exist_plugin('attach') or !function_exists('attach_upload')  )
     {
         return array('msg'=>'attach.inc.php not found or not correct version.');
     }
 
-    // ½ĞÎÏÍÑ¥¨¥ó¥³¡¼¥É¤Î¥µ¥İ¡¼¥È°ìÍ÷(PHP4¤Î»²¹Í½ñ¤è¤ê)
+    // å‡ºåŠ›ç”¨ã‚¨ãƒ³ã‚³ãƒ¼ãƒ‰ã®ã‚µãƒãƒ¼ãƒˆä¸€è¦§(PHP4ã®å‚è€ƒæ›¸ã‚ˆã‚Š)
     $supported_encodes = array("EUC-JP"=>"euc","SJIS"=>"sjis","JIS"=>"jis","UTF-8"=>"utf8");
  
-    // ³Æ¼ï¥Ñ¥é¥á¡¼¥¿¤ÎÆÉ¤ß¹ş¤ß
+    // å„ç¨®ãƒ‘ãƒ©ãƒ¡ãƒ¼ã‚¿ã®èª­ã¿è¾¼ã¿
     $list = array_key_exists('list',$vars)   ? htmlspecialchars($vars['list']) : 'list';
     $order = array_key_exists('order',$vars) ? htmlspecialchars($vars['order']) :'_real:SORT_DESC';
     $encode = array_key_exists('encode',$vars) ? htmlspecialchars($vars['encode']) : NULL ;
     $limit = array_key_exists('limit',$vars) ? htmlspecialchars($vars['limit']) : NULL ;
     if( !is_numeric($limit) )
     {
-        $limit= NULL;  // limit ¤Ï¿ôÃÍ¥Ç¡¼¥¿¤ò¼è¤ë¤¿¤á
+        $limit= NULL;  // limit ã¯æ•°å€¤ãƒ‡ãƒ¼ã‚¿ã‚’å–ã‚‹ãŸã‚
     }
     $config_name = array_key_exists('config',$vars) ? htmlspecialchars($vars['config']) : 'default';
     $filter_name = array_key_exists('filter',$vars) ? htmlspecialchars($vars['filter']) : NULL ;
     $extract_name = array_key_exists('extract',$vars) ? htmlspecialchars($vars['extract']) : NULL;
     
-    // tracker ¤Î configÀßÄê
+    // tracker ã® configè¨­å®š
     $config = new Config('plugin/tracker/'.$config_name);
     if(!$config->read())
     {
@@ -218,7 +218,7 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
     }
     $config->config_name = $config_name;
  
-    // tracker_list ¤Î filterÀßÄê
+    // tracker_list ã® filterè¨­å®š
     $list_filter = NULL;
     if($filter_name != NULL)
     {
@@ -226,7 +226,7 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
         
         if(! $filter_config->read() )
         {
-            // filter ¤ÎÀßÄê¤¬¤Ê¤µ¤ì¤Æ¤¤¤Ê¤±¤ì¤Ğ¡¢¥¨¥é¡¼¥í¥°¤òÊÖ¤¹
+            // filter ã®è¨­å®šãŒãªã•ã‚Œã¦ã„ãªã‘ã‚Œã°ã€ã‚¨ãƒ©ãƒ¼ãƒ­ã‚°ã‚’è¿”ã™
             return array( 'result' => FALSE,
                           'msg' => "<p>config file '".htmlspecialchars($config->page.'/filters')."' not found</p>",
                           );
@@ -234,7 +234,7 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
         $list_filter = &new Tracker_plus_list_filter($filter_config, $filter_name);
     }
     
-    // pages2csv ¤Î extractÀßÄê
+    // pages2csv ã® extractè¨­å®š
     $extract_arg_filter = NULL;
     if($extract_name != NULL)
     {
@@ -242,7 +242,7 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
         
         if( ! $extract_config->read() )
         {
-            // extract ¤ÎÀßÄê¤¬¤Ê¤µ¤ì¤Æ¤¤¤Ê¤±¤ì¤Ğ¡¢¥¨¥é¡¼¥í¥°¤òÊÖ¤¹
+            // extract ã®è¨­å®šãŒãªã•ã‚Œã¦ã„ãªã‘ã‚Œã°ã€ã‚¨ãƒ©ãƒ¼ãƒ­ã‚°ã‚’è¿”ã™
             return array( 'result' => FALSE,
                           'msg' => "<p>config file '".htmlspecialchars($extract_config->page)."' not found</p>",
                           );
@@ -251,11 +251,11 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
     }
     unset($extract_config);
     
-    // ½ĞÎÏÆâÍÆ¤Î¼èÆÀ
+    // å‡ºåŠ›å†…å®¹ã®å–å¾—
     $pstr = plugin_pages2csv_getcsvlist($s_page,$refer,$config,$list,$order,$limit,
                                         $list_filter, $extract_arg_filter);
     
-    // ½ĞÎÏÆâÍÆ¤Î¥¨¥ó¥³¡¼¥Ç¥£¥ó¥°½èÍı
+    // å‡ºåŠ›å†…å®¹ã®ã‚¨ãƒ³ã‚³ãƒ¼ãƒ‡ã‚£ãƒ³ã‚°å‡¦ç†
     if ($encode != '' )
     {
         if( !function_exists('mb_convert_encoding') )
@@ -272,7 +272,7 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
         }
     }
     
-    // ¥Æ¥ó¥İ¥é¥ê¥Õ¥¡¥¤¥ë¤Ø¤Î½ĞÎÏ
+    // ãƒ†ãƒ³ãƒãƒ©ãƒªãƒ•ã‚¡ã‚¤ãƒ«ã¸ã®å‡ºåŠ›
     if( ! ( $tempname = tempnam( UPLOAD_DIR ,"pages2csv_temp") ) || 
         ! ( $fp = fopen($tempname,"w") ) )
     {
@@ -285,7 +285,7 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
     }
     fclose($fp);
     
-    // ÅºÉÕ¥Õ¥¡¥¤¥ëÌ¾¤Î½àÈ÷
+    // æ·»ä»˜ãƒ•ã‚¡ã‚¤ãƒ«åã®æº–å‚™
     $csvfilename = "pages2csv_". date("ymdHi",time());
     if($encode != '')
     {
@@ -293,9 +293,9 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
     }
     $csvfilename .= ".csv";
     
-    // °Ê²¼¡¢attach.inc.php ¤Î attach_upload()´Ø¿ô¤ò»²¹Í¤Ë¤·¤¿
-    // (ÍıÍ³)°·¤¦¥Õ¥¡¥¤¥ë¤¬HTTP POST¤Ç¥¢¥Ã¥×¥í¡¼¥É¤·¤¿¥Õ¥¡¥¤¥ë¤Ç¤Ï¤Ê¤¤¤¿¤á¡¢
-    // ¾åµ­´Ø¿ô¤òÎ®ÍÑ¤¹¤ë¤³¤È¤¬¤Ç¤­¤Ê¤¤¡£
+    // ä»¥ä¸‹ã€attach.inc.php ã® attach_upload()é–¢æ•°ã‚’å‚è€ƒã«ã—ãŸ
+    // (ç†ç”±)æ‰±ã†ãƒ•ã‚¡ã‚¤ãƒ«ãŒHTTP POSTã§ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ã—ãŸãƒ•ã‚¡ã‚¤ãƒ«ã§ã¯ãªã„ãŸã‚ã€
+    // ä¸Šè¨˜é–¢æ•°ã‚’æµç”¨ã™ã‚‹ã“ã¨ãŒã§ããªã„ã€‚
     if (filesize($tempname) > PLUGIN_ATTACH_MAX_FILESIZE )
     {
         unlink($tempname);
@@ -309,10 +309,10 @@ function plugin_pages2csv_upload($vars, $refer, $s_page, $pass)
         return array('result'=>FALSE,'msg'=>$_attach_messages['err_exists']);
     }
     
-    // ÅºÉÕ¥Õ¥¡¥¤¥ë¤ÎÌ¾¾ÎÊÑ¹¹
-    // PHP4.3.3Ì¤Ëş¤Ç¤Ï¡¢rename()¤Ï*nix¥Ù¡¼¥¹¥·¥¹¥Æ¥à¤Ë¤ª¤¤¤Æ¡¢
-    // ¥Ñ¡¼¥Æ¡¼¥·¥ç¥ó±Û¤·¤Ë¥Õ¥¡¥¤¥ëÌ¾¤òÊÑ¹¹¤¹¤ë¤³¤È¤Ï¤Ç¤­¤Ê¤¤¤¿¤á
-    // rename() ¤ÎÂå¤ï¤ê¤Ë copy() ¤òÍÑ¤¤¤ë
+    // æ·»ä»˜ãƒ•ã‚¡ã‚¤ãƒ«ã®åç§°å¤‰æ›´
+    // PHP4.3.3æœªæº€ã§ã¯ã€rename()ã¯*nixãƒ™ãƒ¼ã‚¹ã‚·ã‚¹ãƒ†ãƒ ã«ãŠã„ã¦ã€
+    // ãƒ‘ãƒ¼ãƒ†ãƒ¼ã‚·ãƒ§ãƒ³è¶Šã—ã«ãƒ•ã‚¡ã‚¤ãƒ«åã‚’å¤‰æ›´ã™ã‚‹ã“ã¨ã¯ã§ããªã„ãŸã‚
+    // rename() ã®ä»£ã‚ã‚Šã« copy() ã‚’ç”¨ã„ã‚‹
     if ( copy($tempname,$obj->filename) )
     {
         chmod($obj->filename,PLUGIN_ATTACH_FILE_MODE);
@@ -353,7 +353,7 @@ function plugin_pages2csv_getcsvlist($page,$refer,$config,$list,$order='', $limi
     return $list->toString($limit);
 }
 
-// CSVÍÑ°ìÍ÷¥¯¥é¥¹
+// CSVç”¨ä¸€è¦§ã‚¯ãƒ©ã‚¹
 class Pages2csv_Tracker_csvlist extends Tracker_plus_list
 {
     var $extract_arg_filter = NULL;
@@ -363,7 +363,7 @@ class Pages2csv_Tracker_csvlist extends Tracker_plus_list
     {
         $cache = NULL;
         
-        // ¿Æ¥¯¥é¥¹¤Î¥³¥ó¥¹¥È¥é¥¯¥¿¤ò¸Æ¤Ó½Ğ¤·¤Æ½é´ü²½
+        // è¦ªã‚¯ãƒ©ã‚¹ã®ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã‚’å‘¼ã³å‡ºã—ã¦åˆæœŸåŒ–
         $this->Tracker_plus_list($page,$refer,$config,$list,$filter_name,$cache);
         
         $this->extract_arg_filter = $extract_arg_filter;
@@ -381,7 +381,7 @@ class Pages2csv_Tracker_csvlist extends Tracker_plus_list
         {
             $str = $this->items[$name];
             
-            // »ØÄê¤·¤¿¥×¥é¥°¥¤¥ó¤ÎÆÃÄê¤Î¾ì½ê¤Î°ú¿ôÊ¸»úÎó¤òÃê½Ğ¤¹¤ë
+            // æŒ‡å®šã—ãŸãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®ç‰¹å®šã®å ´æ‰€ã®å¼•æ•°æ–‡å­—åˆ—ã‚’æŠ½å‡ºã™ã‚‹
             if( $this->extract_arg_filter != NULL )
             {
                 $str = $this->extract_arg_filter->extracts($str);
@@ -408,8 +408,8 @@ class Pages2csv_Tracker_csvlist extends Tracker_plus_list
             $str = $arr[0];
         }
 
-        // ¥¹¥¿¥¤¥ë½ĞÎÏ¤ò½ü¤¯
-        // ¤³¤³¤Ç¥×¥é¥°¥¤¥ó¤Î°ú¿ô¤òÃê½Ğ¤¹¤ë¡£
+        // ã‚¹ã‚¿ã‚¤ãƒ«å‡ºåŠ›ã‚’é™¤ã
+        // ã“ã“ã§ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®å¼•æ•°ã‚’æŠ½å‡ºã™ã‚‹ã€‚
         
         return $this->pipe ? str_replace('|','&#x7c;',$str) : $str;
   
@@ -417,7 +417,7 @@ class Pages2csv_Tracker_csvlist extends Tracker_plus_list
   
     function replace_title($arr)
     {
-        // ¥¹¥¿¥¤¥ë½ĞÎÏ¤ò½ü¤¯
+        // ã‚¹ã‚¿ã‚¤ãƒ«å‡ºåŠ›ã‚’é™¤ã
         global $script;
         
         $field = $arr[1];
@@ -428,7 +428,7 @@ class Pages2csv_Tracker_csvlist extends Tracker_plus_list
         
         $title = $this->fields[$field]->title;
         
-        // ¥ê¥ó¥¯¾ğÊó¤Ê¤É¤Ï³°¤·¤Æ..
+        // ãƒªãƒ³ã‚¯æƒ…å ±ãªã©ã¯å¤–ã—ã¦..
         return "$title";
     }
     
@@ -459,7 +459,7 @@ class Pages2csv_Tracker_csvlist extends Tracker_plus_list
 
             if (preg_match('/^\|(.+)\|[hH]$/',$line) )
             {
-                // É½ÄêµÁ¤Î¥Ñ¥¤¥×¶èÀÚ¤ê¤òCSV·Á¼°¶èÀÚ¤ê¤ËÊÑ¹¹
+                // è¡¨å®šç¾©ã®ãƒ‘ã‚¤ãƒ—åŒºåˆ‡ã‚Šã‚’CSVå½¢å¼åŒºåˆ‡ã‚Šã«å¤‰æ›´
                 // $line = preg_replace('/^",(.+),"|[hHfF]$/','$1',$line);
                 $line = preg_replace('/\|/',',', $line); 
                 $line = preg_replace('/\~/','', $line); 
@@ -476,7 +476,7 @@ class Pages2csv_Tracker_csvlist extends Tracker_plus_list
             }
             else
             {
-                // É½ÄêµÁ¤Î¥Ñ¥¤¥×¶èÀÚ¤ê¤òCSV·Á¼°¶èÀÚ¤ê¤ËÊÑ¹¹
+                // è¡¨å®šç¾©ã®ãƒ‘ã‚¤ãƒ—åŒºåˆ‡ã‚Šã‚’CSVå½¢å¼åŒºåˆ‡ã‚Šã«å¤‰æ›´
                 $line = preg_replace('/\|/','","', $line); 
                 $line = preg_replace('/^",(.+),"$/','$1',$line);
                 

--- a/tracker_plus.inc.php/tracker_plus.inc.php
+++ b/tracker_plus.inc.php/tracker_plus.inc.php
@@ -10,41 +10,41 @@
 require_once(PLUGIN_DIR . 'tracker.inc.php');
 
 /////////////////////////////////////////////////////////////////////////////
-// tracker_list¤ÇÉ½¼¨¤·¤Ê¤¤¥Ú¡¼¥¸Ì¾(Àµµ¬É½¸½¤Ç)
-// 'SubMenu'¥Ú¡¼¥¸ ¤ª¤è¤Ó '/'¤ò´Ş¤à¥Ú¡¼¥¸¤ò½ü³°¤¹¤ë
+// tracker_listã§è¡¨ç¤ºã—ãªã„ãƒšãƒ¼ã‚¸å(æ­£è¦è¡¨ç¾ã§)
+// 'SubMenu'ãƒšãƒ¼ã‚¸ ãŠã‚ˆã³ '/'ã‚’å«ã‚€ãƒšãƒ¼ã‚¸ã‚’é™¤å¤–ã™ã‚‹
 define('TRACKER_PLUS_LIST_EXCLUDE_PATTERN','#^SubMenu$|/#');
-// À©¸Â¤·¤Ê¤¤¾ì¹ç¤Ï¤³¤Á¤é
+// åˆ¶é™ã—ãªã„å ´åˆã¯ã“ã¡ã‚‰
 //define('TRACKER_PLUS_LIST_EXCLUDE_PATTERN','#(?!)#');
 
 /////////////////////////////////////////////////////////////////////////////
-// ¹àÌÜ¤Î¼è¤ê½Ğ¤·¤Ë¼ºÇÔ¤·¤¿¥Ú¡¼¥¸¤ò°ìÍ÷¤ËÉ½¼¨¤¹¤ë
+// é …ç›®ã®å–ã‚Šå‡ºã—ã«å¤±æ•—ã—ãŸãƒšãƒ¼ã‚¸ã‚’ä¸€è¦§ã«è¡¨ç¤ºã™ã‚‹
 define('TRACKER_PLUS_LIST_SHOW_ERROR_PAGE',TRUE);
 
 /////////////////////////////////////////////////////////////////////////////
-// CacheLevel¤Î¥Ç¥Õ¥©¥ë¥È¤ÎÀßÄê
-// ** ÀßÄêÃÍ¤ÎÀâÌÀ ** Éé¤ÎÃÍ¤Ï¾éÄ¹¥â¡¼¥É¤òÉ½¤·¤Ş¤¹
-//        0 : ¥­¥ã¥Ã¥·¥å¥í¥¸¥Ã¥¯¤òÍøÍÑ¤·¤Ê¤¤ 
-//  1 or -1 : ¥Ú¡¼¥¸¤ÎÆÉ¤ß¹ş¤ß½èÍı¤ËÂĞ¤¹¤ë¥­¥ã¥Ã¥·¥å¤òÍ­¸ú¤Ë¤¹¤ë
-//  2 or -2 : html¤ËÊÑ´¹¸å¤Î¥Ç¡¼¥¿¤Î¥­¥ã¥Ã¥·¥å¤òÍ­¸ú¤Ë¤¹¤ë
+// CacheLevelã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®è¨­å®š
+// ** è¨­å®šå€¤ã®èª¬æ˜ ** è² ã®å€¤ã¯å†—é•·ãƒ¢ãƒ¼ãƒ‰ã‚’è¡¨ã—ã¾ã™
+//        0 : ã‚­ãƒ£ãƒƒã‚·ãƒ¥ãƒ­ã‚¸ãƒƒã‚¯ã‚’åˆ©ç”¨ã—ãªã„ 
+//  1 or -1 : ãƒšãƒ¼ã‚¸ã®èª­ã¿è¾¼ã¿å‡¦ç†ã«å¯¾ã™ã‚‹ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’æœ‰åŠ¹ã«ã™ã‚‹
+//  2 or -2 : htmlã«å¤‰æ›å¾Œã®ãƒ‡ãƒ¼ã‚¿ã®ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’æœ‰åŠ¹ã«ã™ã‚‹
 define('TRACKER_PLUS_LIST_CACHE_DEFAULT', 0); 
 // define('TRACKER_PLUS_LIST_CACHE_DEFAULT', 1); 
 // define('TRACKER_PLUS_LIST_CACHE_DEFAULT', 2); 
 
 /////////////////////////////////////////////////////////////////////////////
 // [Dynamic Filter Configration Section]
-// ¥Õ¥£¥ë¥¿¤ò»ØÄê»ş¤Ë¤ª¤±¤ë¡¢Æ°Åª¥Õ¥£¥ë¥¿ÁªÂò¤Î¥Ç¥Õ¥©¥ë¥ÈÀßÄê
-//  ** ÀßÄêÃÍ¤ÎÀâÌÀ ** filterÌ¾¤ÎÆ¬¤Ë + or - ¤òÉÕ¤±¤ë¤È¥ê¥¹¥ÈÉ½¼¨¤ÎÀ©¸æ¤Ï²ÄÇ½¤Ç¤¹¤¬...
-//   TRUE : filterÌ¾¤ÎÀèÆ¬¤Ë + ¤ò»ØÄê¤·¤Ê¤¯¤Æ¤â¥Õ¥£¥ë¥¿ÁªÂòÍÑ¤Î¥ê¥¹¥È¤òÉ½¼¨¤·¤Ş¤¹
-//  FALSE : filterÌ¾¤ÎÀèÆ¬¤Ë + ¤ò»ØÄê¤·¤Ê¤¤¤È¡¢¥Õ¥£¥ë¥¿ÁªÂòÍÑ¤Î¥ê¥¹¥È¤ÏÉ½¼¨¤·¤Ş¤»¤ó
+// ãƒ•ã‚£ãƒ«ã‚¿ã‚’æŒ‡å®šæ™‚ã«ãŠã‘ã‚‹ã€å‹•çš„ãƒ•ã‚£ãƒ«ã‚¿é¸æŠã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆè¨­å®š
+//  ** è¨­å®šå€¤ã®èª¬æ˜ ** filteråã®é ­ã« + or - ã‚’ä»˜ã‘ã‚‹ã¨ãƒªã‚¹ãƒˆè¡¨ç¤ºã®åˆ¶å¾¡ã¯å¯èƒ½ã§ã™ãŒ...
+//   TRUE : filteråã®å…ˆé ­ã« + ã‚’æŒ‡å®šã—ãªãã¦ã‚‚ãƒ•ã‚£ãƒ«ã‚¿é¸æŠç”¨ã®ãƒªã‚¹ãƒˆã‚’è¡¨ç¤ºã—ã¾ã™
+//  FALSE : filteråã®å…ˆé ­ã« + ã‚’æŒ‡å®šã—ãªã„ã¨ã€ãƒ•ã‚£ãƒ«ã‚¿é¸æŠç”¨ã®ãƒªã‚¹ãƒˆã¯è¡¨ç¤ºã—ã¾ã›ã‚“
 define('TRACKER_PLUS_LIST_DYNAMIC_FILTER_DEFAULT', TRUE);
 //
 /////////////////////////////////////////////////////////////////////////////
-// Æ°Åª¥Õ¥£¥ë¥¿¤Î¥ê¥¹¥È¥é¥Ù¥ë¤Î³ÈÄ¥ÀßÄê
+// å‹•çš„ãƒ•ã‚£ãƒ«ã‚¿ã®ãƒªã‚¹ãƒˆãƒ©ãƒ™ãƒ«ã®æ‹¡å¼µè¨­å®š
 define('TRACKER_PLUS_LIST_APPLY_LISTFORMAT',TRUE);
 //
 //////////////////////////////////////////////////////////////////////////////
 // [Paging Configration Section] 
-// ¥ê¥¹¥ÈÉ½¼¨»ş¤Î¥Ú¡¼¥¸¥ó¥°µ¡Ç½¤ÎÀßÄê
+// ãƒªã‚¹ãƒˆè¡¨ç¤ºæ™‚ã®ãƒšãƒ¼ã‚¸ãƒ³ã‚°æ©Ÿèƒ½ã®è¨­å®š
 // 0: Disable paging ( same as tracker.inc.php)
 // 1:  Enable paging with only LinkMark.
 // 2:  Enable paging with only less/more MarkStr.
@@ -53,13 +53,13 @@ define('TRACKER_PLUS_LIST_APPLY_LISTFORMAT',TRUE);
 //define('TRACKER_PLUS_LIST_PAGING', 1);
 //define('TRACKER_PLUS_LIST_PAGING', 2);
 define('TRACKER_PLUS_LIST_PAGING', 3);
-// °ìÅÙ¤ËÉ½¼¨¤¹¤ë linkMark ¤Î¿ô 
+// ä¸€åº¦ã«è¡¨ç¤ºã™ã‚‹ linkMark ã®æ•° 
 define('TRACKER_PLUS_LIST_PAGING_MARK_NUMBER_PER_ONCE', 10);
 //
 /////////////////////////////////////////////////////////////////////////////
-// ¥ê¥¹¥ÈºîÀ®»ş¤Ë¥Ú¡¼¥¸¥ì¥¤¥¢¥¦¥È¤òÉ¾²Á¤¹¤ëÈÏ°Ï¤ò
-// "//////////" ¤ÎÄ¾Á°¤Ş¤Ç¤ËÀ©¸Â¤¹¤ë.
-// ( ¥Ñ¥¿¡¼¥ó¥Ş¥Ã¥Á¥ó¥°¤¹¤ë¥ì¥¤¥¢¥¦¥ÈÈÏ°Ï¤ÎÀ©¸æ
+// ãƒªã‚¹ãƒˆä½œæˆæ™‚ã«ãƒšãƒ¼ã‚¸ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆã‚’è©•ä¾¡ã™ã‚‹ç¯„å›²ã‚’
+// "//////////" ã®ç›´å‰ã¾ã§ã«åˆ¶é™ã™ã‚‹.
+// ( ãƒ‘ã‚¿ãƒ¼ãƒ³ãƒãƒƒãƒãƒ³ã‚°ã™ã‚‹ãƒ¬ã‚¤ã‚¢ã‚¦ãƒˆç¯„å›²ã®åˆ¶å¾¡
 define('TRACKER_PLUS_LIST_APPLY_LIMIT_PARSERANGE',TRUE);
 //
 // *** Definition for codes, Don't modify...***
@@ -84,20 +84,20 @@ function plugin_tracker_plus_init_ja()
     $msg = array(
      //        '_tracker_plus_msg' => array(),
         '_tracker_plus_list_msg' => array(
-            'nodata'             => '°ìÍ÷¤ËÉ½¼¨¤¹¤ë¹àÌÜ¤Ï¤¢¤ê¤Ş¤»¤ó.',
-            'paging'             => 'Á´ $1·ïÃæ¡¢$2 ·ïÌÜ ¤«¤é $3 ·ïÌÜ ¤Ş¤ÇÉ½¼¨¤·¤Æ¤¤¤Ş¤¹.' ,
-            'paging_linkMark'    => '¢£',
-            'paging_lessMark'    => '¡Ô',
-            'paging_moreMark'    => '¡Õ',
-            'paging_lessMarkStr' => '[Á°¤Î $1 ·ï]',
-            'paging_moreMarkStr' => '[¼¡¤Î $1 ·ï]',
-            'filter_label'          => '¹Ê¤ê¹ş¤ß¾ò·ï°ìÍ÷',
-            'filter_extTitle'    => '³ÈÄ¥¸«½Ğ¤·',
-            'filter_title_logicalOperator' => 'Ï¢·ë¾ò·ï',
-            'filter_title_targetField'     => 'ÂĞ¾İ¹àÌÜ',
-            'filter_title_operator'        => '¾ò·ï',
-            'filter_title_conditionValues' => '¾ò·ïÃÍ',
-            'filter_definition_error'      => '¥Õ¥£¥ë¥¿¾ò·ï¤¬ÉÔÀµ¤Ç¤¹'
+            'nodata'             => 'ä¸€è¦§ã«è¡¨ç¤ºã™ã‚‹é …ç›®ã¯ã‚ã‚Šã¾ã›ã‚“.',
+            'paging'             => 'å…¨ $1ä»¶ä¸­ã€$2 ä»¶ç›® ã‹ã‚‰ $3 ä»¶ç›® ã¾ã§è¡¨ç¤ºã—ã¦ã„ã¾ã™.' ,
+            'paging_linkMark'    => 'â– ',
+            'paging_lessMark'    => 'ã€Š',
+            'paging_moreMark'    => 'ã€‹',
+            'paging_lessMarkStr' => '[å‰ã® $1 ä»¶]',
+            'paging_moreMarkStr' => '[æ¬¡ã® $1 ä»¶]',
+            'filter_label'          => 'çµã‚Šè¾¼ã¿æ¡ä»¶ä¸€è¦§',
+            'filter_extTitle'    => 'æ‹¡å¼µè¦‹å‡ºã—',
+            'filter_title_logicalOperator' => 'é€£çµæ¡ä»¶',
+            'filter_title_targetField'     => 'å¯¾è±¡é …ç›®',
+            'filter_title_operator'        => 'æ¡ä»¶',
+            'filter_title_conditionValues' => 'æ¡ä»¶å€¤',
+            'filter_definition_error'      => 'ãƒ•ã‚£ãƒ«ã‚¿æ¡ä»¶ãŒä¸æ­£ã§ã™'
         )
     ); 
     return $msg;
@@ -110,9 +110,9 @@ function plugin_tracker_plus_init_en()
         '_tracker_plus_list_msg' => array(
             'nodata'             => 'There is no item displayed in List.',
             'paging'             => 'This displays it from the $2 th to the $3 th among $1.',
-            'paging_linkMark'    => '¢£',
-            'paging_lessMark'    => '¡Ô',
-            'paging_moreMark'    => '¡Õ',
+            'paging_linkMark'    => 'â– ',
+            'paging_lessMark'    => 'ã€Š',
+            'paging_moreMark'    => 'ã€‹',
             'paging_lessMarkStr' => '[Before $1 ]',
             'paging_moreMarkStr' => '[Next $1 ]',
             'filter_label'       => 'FilterList of TrackerList',
@@ -267,7 +267,7 @@ function plugin_tracker_plus_action()
             'body'=>'page template ('.htmlspecialchars($source).') is not exist.'
         );
     }
-    // ¥Ú¡¼¥¸Ì¾¤ò·èÄê
+    // ãƒšãƒ¼ã‚¸åã‚’æ±ºå®š
     $base = $post['_base'];
     $num = 0;
     $name = (array_key_exists('_name',$post)) ? $post['_name'] : '';
@@ -294,10 +294,10 @@ function plugin_tracker_plus_action()
     // org: QuestionBox3/211: Apply edit_auth_pages to creating page
     edit_auth($page,true,true);
 
-    // ¥Ú¡¼¥¸¥Ç¡¼¥¿¤òÀ¸À®
+    // ãƒšãƒ¼ã‚¸ãƒ‡ãƒ¼ã‚¿ã‚’ç”Ÿæˆ
     $postdata = plugin_tracker_plus_get_source($source);
 
-    // µ¬Äê¤Î¥Ç¡¼¥¿
+    // è¦å®šã®ãƒ‡ãƒ¼ã‚¿
     $_post = array_merge($post,$_FILES);
     $_post['_date'] = $now;
     $_post['_page'] = $page;
@@ -350,23 +350,23 @@ function plugin_tracker_plus_action()
     exit;
 }
 
-// ¥Õ¥£¡¼¥ë¥É¥ª¥Ö¥¸¥§¥¯¥È¤ò¹½ÃÛ¤¹¤ë
+// ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’æ§‹ç¯‰ã™ã‚‹
 function plugin_tracker_plus_get_fields($base,$refer,&$config)
 {
     global $now,$_tracker_messages;
 
     $fields = array();
-    // Í½Ìó¸ì
+    // äºˆç´„èª
     foreach( array(
-                 '_date'   => 'text',        // Åê¹ÆÆü»ş
-                 '_update' => 'date',        // ºÇ½ª¹¹¿·
-                 '_past'   => 'past',        // ·Ğ²á(passage)
-                 '_page'   => 'page',        // ¥Ú¡¼¥¸Ì¾
-                 '_name'   => 'text',        // »ØÄê¤µ¤ì¤¿¥Ú¡¼¥¸Ì¾
-                 '_real'   => 'real',        // ¼Âºİ¤Î¥Ú¡¼¥¸Ì¾
-                 '_refer'  => 'page',        // »²¾È¸µ(¥Õ¥©¡¼¥à¤Î¤¢¤ë¥Ú¡¼¥¸)
-                 '_base'   => 'page',        // ´ğ½à¥Ú¡¼¥¸
-                 '_submit' => 'submit_plus', // ÄÉ²Ã¥Ü¥¿¥ó
+                 '_date'   => 'text',        // æŠ•ç¨¿æ—¥æ™‚
+                 '_update' => 'date',        // æœ€çµ‚æ›´æ–°
+                 '_past'   => 'past',        // çµŒé(passage)
+                 '_page'   => 'page',        // ãƒšãƒ¼ã‚¸å
+                 '_name'   => 'text',        // æŒ‡å®šã•ã‚ŒãŸãƒšãƒ¼ã‚¸å
+                 '_real'   => 'real',        // å®Ÿéš›ã®ãƒšãƒ¼ã‚¸å
+                 '_refer'  => 'page',        // å‚ç…§å…ƒ(ãƒ•ã‚©ãƒ¼ãƒ ã®ã‚ã‚‹ãƒšãƒ¼ã‚¸)
+                 '_base'   => 'page',        // åŸºæº–ãƒšãƒ¼ã‚¸
+                 '_submit' => 'submit_plus', // è¿½åŠ ãƒœã‚¿ãƒ³
                  ) as $field=>$class)
     {
         $class = 'Tracker_field_'.$class;
@@ -375,10 +375,10 @@ function plugin_tracker_plus_get_fields($base,$refer,&$config)
 
     foreach( $config->get('fields') as $field)
     {
-        // 0=>¹àÌÜÌ¾ 1=>¸«½Ğ¤· 2=>·Á¼° 3=>¥ª¥×¥·¥ç¥ó 4=>¥Ç¥Õ¥©¥ë¥ÈÃÍ
+        // 0=>é …ç›®å 1=>è¦‹å‡ºã— 2=>å½¢å¼ 3=>ã‚ªãƒ—ã‚·ãƒ§ãƒ³ 4=>ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆå€¤
         $class = 'Tracker_field_'.$field[2];
         if( ! class_exists($class) )
-        { // ¥Ç¥Õ¥©¥ë¥È
+        { // ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆ
             $class = 'Tracker_field_text';
             $field[2] = 'text';
             $field[3] = '20';
@@ -390,7 +390,7 @@ function plugin_tracker_plus_get_fields($base,$refer,&$config)
 
 
 ///////////////////////////////////////////////////////////////////////////
-// °ìÍ÷É½¼¨
+// ä¸€è¦§è¡¨ç¤º
 function plugin_tracker_plus_list_convert()
 {
     global $vars;
@@ -502,7 +502,7 @@ function plugin_tracker_plus_getlist($page, $refer, $config_name, $list_name, $o
 
         if( ! $filter_config->read() && $list->filter_name != NULL )
         {
-                // filter¤ÎÀßÄê¤¬¤Ê¤µ¤ì¤Æ¤¤¤Ê¤±¤ì¤Ğ, ¥¨¥é¡¼¥í¥°¤òÊÖ¤¹
+                // filterã®è¨­å®šãŒãªã•ã‚Œã¦ã„ãªã‘ã‚Œã°, ã‚¨ãƒ©ãƒ¼ãƒ­ã‚°ã‚’è¿”ã™
                 return "<p>config file '".htmlspecialchars($config->page.'/filters')."' not found</p>";
         }
 
@@ -583,22 +583,22 @@ class Tracker_plus_FilterConfig extends Config
 }
 
 
-// °ìÍ÷¥¯¥é¥¹
+// ä¸€è¦§ã‚¯ãƒ©ã‚¹
 class Tracker_plus_list extends Tracker_list
 {
     var $filter_name;
     var $dynamic_filter = TRACKER_PLUS_LIST_DYNAMIC_FILTER_DEFAULT;
     var $orefer;
     var $cache_level = array(
-               'NO'  => 0, // ¥­¥ã¥Ã¥·¥å¥í¥¸¥Ã¥¯¤òÍøÍÑ¤·¤Ê¤¤
-               'LV1' => 1, // ¥Ú¡¼¥¸¤ÎÆÉ¤ß¹ş¤ß½èÍı¤ËÂĞ¤¹¤ë¥­¥ã¥Ã¥·¥å¤òÍ­¸ú¤Ë¤¹¤ë
-               'LV2' => 2, // html¤ËÊÑ´¹¸å¤Î¥Ç¡¼¥¿¤Î¥­¥ã¥Ã¥·¥å¤òÍ­¸ú¤Ë¤¹¤ë
+               'NO'  => 0, // ã‚­ãƒ£ãƒƒã‚·ãƒ¥ãƒ­ã‚¸ãƒƒã‚¯ã‚’åˆ©ç”¨ã—ãªã„
+               'LV1' => 1, // ãƒšãƒ¼ã‚¸ã®èª­ã¿è¾¼ã¿å‡¦ç†ã«å¯¾ã™ã‚‹ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’æœ‰åŠ¹ã«ã™ã‚‹
+               'LV2' => 2, // htmlã«å¤‰æ›å¾Œã®ãƒ‡ãƒ¼ã‚¿ã®ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã‚’æœ‰åŠ¹ã«ã™ã‚‹
                );
 
     var $cache = array('level' => TRACKER_PLUS_LIST_CACHE_DEFAULT ,
-               'state' => array('stored_total' => 0,  // cache¤Ë¤¢¤ë¥Ç¡¼¥¿¿ô
-                        'hits' => 0,          // cacheÆâ¤Ë¤¢¤ëÍ­¸ú¤Ê¥Ç¡¼¥¿¿ô
-                        'total' => 0,         // ¹¹¿·Ê¬¤ò´Ş¤á¤ÆºÇ½ªÅª¤ËÍ­¸ú¤Ê¥Ç¡¼¥¿¿ô
+               'state' => array('stored_total' => 0,  // cacheã«ã‚ã‚‹ãƒ‡ãƒ¼ã‚¿æ•°
+                        'hits' => 0,          // cacheå†…ã«ã‚ã‚‹æœ‰åŠ¹ãªãƒ‡ãƒ¼ã‚¿æ•°
+                        'total' => 0,         // æ›´æ–°åˆ†ã‚’å«ã‚ã¦æœ€çµ‚çš„ã«æœ‰åŠ¹ãªãƒ‡ãƒ¼ã‚¿æ•°
                         'cnvrt' => FALSE), 
                'verbs' => FALSE,
                );
@@ -629,20 +629,20 @@ class Tracker_plus_list extends Tracker_list
         
         $pattern = join('',plugin_tracker_plus_get_source($config->page.'/page'));
         
-        // "/page"¤ÎÆâÍÆ¤¬Ä¹¤¹¤®¤ë¤Èpreg_match()¤¬¼ºÇÔ¤¹¤ë¥Ğ¥°(?)¤¬¤¢¤ë¤Î¤Ç
-        // "//////////"¤Ş¤Ç¤ò¥Ş¥Ã¥ÁÂĞ¾İ¤È¤µ¤»¤ë
-        // ( see http://dex.qp.land.to/pukiwiki.php, Top/Memo/Wiki¥á¥â)
+        // "/page"ã®å†…å®¹ãŒé•·ã™ãã‚‹ã¨preg_match()ãŒå¤±æ•—ã™ã‚‹ãƒã‚°(?)ãŒã‚ã‚‹ã®ã§
+        // "//////////"ã¾ã§ã‚’ãƒãƒƒãƒå¯¾è±¡ã¨ã•ã›ã‚‹
+        // ( see http://dex.qp.land.to/pukiwiki.php, Top/Memo/Wikiãƒ¡ãƒ¢)
         $pattern_endpos = strpos($pattern, "//////////");
         if( $pattern_endpos > 0 )
         {
             $pattern = substr($pattern, 0, $pattern_endpos);
         }
         
-        // ¥Ö¥í¥Ã¥¯¥×¥é¥°¥¤¥ó¤ò¥Õ¥£¡¼¥ë¥É¤ËÃÖ´¹
-        // #comment¤Ê¤É¤ÇÁ°¸å¤ËÊ¸»úÎó¤ÎÁı¸º¤¬¤¢¤Ã¤¿¾ì¹ç¤Ë¡¢[_block_xxx]¤ËµÛ¤¤¹ş¤Ş¤»¤ë¤è¤¦¤Ë¤¹¤ë
+        // ãƒ–ãƒ­ãƒƒã‚¯ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ã«ç½®æ›
+        // #commentãªã©ã§å‰å¾Œã«æ–‡å­—åˆ—ã®å¢—æ¸›ãŒã‚ã£ãŸå ´åˆã«ã€[_block_xxx]ã«å¸ã„è¾¼ã¾ã›ã‚‹ã‚ˆã†ã«ã™ã‚‹
         $pattern = preg_replace('/^\#([^\(\s]+)(?:\((.*)\))?\s*$/m','[_block_$1]',$pattern);
 
-        // ¥Ñ¥¿¡¼¥ó¤òÀ¸À®
+        // ãƒ‘ã‚¿ãƒ¼ãƒ³ã‚’ç”Ÿæˆ
         $this->pattern = '';
         $this->pattern_fields = array();
         $pattern = preg_split('/\\\\\[(\w+)\\\\\]/',preg_quote($pattern,'/'),-1,PREG_SPLIT_DELIM_CAPTURE);
@@ -660,11 +660,11 @@ class Tracker_plus_list extends Tracker_list
         $this->cache['verbs'] = ($cache < 0) ? TRUE : FALSE;
         $this->cache['level'] = (abs($cache) <= $this->cache_level['LV2']) ? abs($cache) : $this->cache_level['NO']; 
 
-        // ¥Ú¡¼¥¸¤ÎÎóµó¤È¼è¤ê¹ş¤ß
+        // ãƒšãƒ¼ã‚¸ã®åˆ—æŒ™ã¨å–ã‚Šè¾¼ã¿
 
-        // cache ¤«¤é cacheºîÀ®»ş¹ï¤«¤é¥Ç¡¼¥¿¤ò¼è¤ê¹ş¤à
-        // $this->add()¤Ç¤Î½èÍı¤ÎÁ°¤Ë¤¢¤é¤«¤¸¤á cache ¤«¤é¼è¤ê¹ş¤ó¤Ç¤ª¤¯¤³¤È¤Ç¡¢
-        // $this->add()¤ÎÌµ¸Â¥ë¡¼¥×ËÉ»ß¥í¥¸¥Ã¥¯¤òÍøÍÑ¤·¤Æ¡¢ÂĞ¾İ¥Ç¡¼¥¿¤ò´Ş¤à¥Ú¡¼¥¸¤ÎÆÉ¤ß¹ş¤ß¤ò¹Ô¤ï¤»¤Ê¤¤¡£
+        // cache ã‹ã‚‰ cacheä½œæˆæ™‚åˆ»ã‹ã‚‰ãƒ‡ãƒ¼ã‚¿ã‚’å–ã‚Šè¾¼ã‚€
+        // $this->add()ã§ã®å‡¦ç†ã®å‰ã«ã‚ã‚‰ã‹ã˜ã‚ cache ã‹ã‚‰å–ã‚Šè¾¼ã‚“ã§ãŠãã“ã¨ã§ã€
+        // $this->add()ã®ç„¡é™ãƒ«ãƒ¼ãƒ—é˜²æ­¢ãƒ­ã‚¸ãƒƒã‚¯ã‚’åˆ©ç”¨ã—ã¦ã€å¯¾è±¡ãƒ‡ãƒ¼ã‚¿ã‚’å«ã‚€ãƒšãƒ¼ã‚¸ã®èª­ã¿è¾¼ã¿ã‚’è¡Œã‚ã›ãªã„ã€‚
         $this->get_cache_rows();
 
         $pattern = "$page/";
@@ -690,7 +690,7 @@ class Tracker_plus_list extends Tracker_list
 	{
 		static $moved = array();
 
-		// Ìµ¸Â¥ë¡¼¥×ËÉ»ß
+		// ç„¡é™ãƒ«ãƒ¼ãƒ—é˜²æ­¢
 		if (array_key_exists($name,$this->rows))
 		{
 			return;
@@ -709,8 +709,8 @@ class Tracker_plus_list extends Tracker_list
 		}
 		$source = join('',preg_replace('/^(\*{1,3}.*)\[#[A-Za-z][\w-]+\](.*)$/','$1$2',$source));
 
-        // "/page"¤ÎÆâÍÆ¤¬Ä¹¤¹¤®¤ë¤Èpreg_match()¤¬¼ºÇÔ¤¹¤ë¥Ğ¥°(?)¤¬¤¢¤ë¤Î¤Ç
-        // "//////////"¤Ş¤Ç¤ò¥Ş¥Ã¥ÁÂĞ¾İ¤È¤µ¤»¤ë
+        // "/page"ã®å†…å®¹ãŒé•·ã™ãã‚‹ã¨preg_match()ãŒå¤±æ•—ã™ã‚‹ãƒã‚°(?)ãŒã‚ã‚‹ã®ã§
+        // "//////////"ã¾ã§ã‚’ãƒãƒƒãƒå¯¾è±¡ã¨ã•ã›ã‚‹
         if( TRACKER_PLUS_LIST_APPLY_LIMIT_PARSERANGE )
         {
             $source_endpos = strpos($source, "//////////");
@@ -720,7 +720,7 @@ class Tracker_plus_list extends Tracker_list
             }
         }
 
-		// ¥Ç¥Õ¥©¥ë¥ÈÃÍ
+		// ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆå€¤
 		$this->rows[$name] = array(
 			'_page'  => "[[$page]]",
 			'_refer' => $this->page,
@@ -1383,7 +1383,7 @@ EOD;
             return ;
         }
 
-        // toString() ¤Î·ë²Ì¤ò¥­¥ã¥Ã¥·¥å¤È¤·¤Æ½ñ¤­½Ğ¤¹
+        // toString() ã®çµæœã‚’ã‚­ãƒ£ãƒƒã‚·ãƒ¥ã¨ã—ã¦æ›¸ãå‡ºã™
         $cachefile = $this->get_cnvtcache_filename(); 
 
         // If $filename exist, fopen() with 'w' mode destories file contents before acquiring flock() 
@@ -1730,7 +1730,7 @@ class Tracker_field_select2 extends Tracker_field_select
 {
     var $sort_type = SORT_NUMERIC;
   
-    //Tracker_field_select ¤Ë¤¢¤ëmultiple »ØÄê¤¬¤Ç¤­¤Ê¤¤¤è¤¦¤Ë¤¹¤ë¡£
+    //Tracker_field_select ã«ã‚ã‚‹multiple æŒ‡å®šãŒã§ããªã„ã‚ˆã†ã«ã™ã‚‹ã€‚
     function get_tag($empty=FALSE)
     {
         $s_name = htmlspecialchars($this->name);
@@ -1752,13 +1752,13 @@ class Tracker_field_select2 extends Tracker_field_select
         return $retval;
     }
   
-    // (sort¤ÎÅ¬ÍÑ»ş¤ËÍøÍÑ)
-    // °ú¿ô(pageÆâ¤Î³ºÅöÉôÊ¬)¤Ëconfig¥Ú¡¼¥¸¤ÎÂ°À­ÃÍ°ìÍ÷¤ÇÄêµÁ¤·¤¿Í×ÁÇ¤¬´Ş¤Ş¤ì¤ì¤Ğ¡¢
-    // Â°À­ÃÍ°ìÍ÷¤ÇÄêµÁ¤µ¤ì¤¿¡¢¸«½Ğ¤·¤ÎÃÍ¤òÊÖ¤¹
+    // (sortã®é©ç”¨æ™‚ã«åˆ©ç”¨)
+    // å¼•æ•°(pageå†…ã®è©²å½“éƒ¨åˆ†)ã«configãƒšãƒ¼ã‚¸ã®å±æ€§å€¤ä¸€è¦§ã§å®šç¾©ã—ãŸè¦ç´ ãŒå«ã¾ã‚Œã‚Œã°ã€
+    // å±æ€§å€¤ä¸€è¦§ã§å®šç¾©ã•ã‚ŒãŸã€è¦‹å‡ºã—ã®å€¤ã‚’è¿”ã™
     function get_value($value)
     {
-        // config ¥Ú¡¼¥¸¤ÎÂ°À­ÃÍ¤ÎÆÉ¤ß¼è¤ê¡¢
-        // ¤³¤ÎÂ°À­ÃÍ¤ËÂĞ¤·¤Æ»ØÄê½ç¤Ë¾º½ç¤Ë¿ô¤ò¿¶¤Ã¤¿ÇÛÎó¤òºîÀ®¤¹¤ë
+        // config ãƒšãƒ¼ã‚¸ã®å±æ€§å€¤ã®èª­ã¿å–ã‚Šã€
+        // ã“ã®å±æ€§å€¤ã«å¯¾ã—ã¦æŒ‡å®šé †ã«æ˜‡é †ã«æ•°ã‚’æŒ¯ã£ãŸé…åˆ—ã‚’ä½œæˆã™ã‚‹
         static $options = array();
         if( ! array_key_exists($this->name,$options))
         { 
@@ -1768,8 +1768,8 @@ class Tracker_field_select2 extends Tracker_field_select
 
         $regmatch_value=$this->get_key($value);
 
-        // ³ºÅöÃÍ¤¬ config ¥Ú¡¼¥¸¤Ç»ØÄê¤µ¤ì¤¿ÃÍ¤Ç¤¢¤ì¤Ğ¡¢
-        // ¾åµ­¤Çµá¤á¤¿ÀßÄê½ç¤ò¼¨¤¹ÃÍ¤òÊÖ¤¹
+        // è©²å½“å€¤ãŒ config ãƒšãƒ¼ã‚¸ã§æŒ‡å®šã•ã‚ŒãŸå€¤ã§ã‚ã‚Œã°ã€
+        // ä¸Šè¨˜ã§æ±‚ã‚ãŸè¨­å®šé †ã‚’ç¤ºã™å€¤ã‚’è¿”ã™
         if( array_key_exists($regmatch_value,$options[$this->name]) ) 
         {
             return $options[$this->name][$regmatch_value];
@@ -1780,18 +1780,18 @@ class Tracker_field_select2 extends Tracker_field_select
         }
     }
   
-    // (style¤ÎÅ¬ÍÑ»ş¡¢listÉ½¼¨ÆâÍÆ¤Ë¡¢ÍøÍÑ¤µ¤ì¤ë)
-    // °ú¿ô(pageÆâ¤Î³ºÅöÉôÊ¬)¤Ëconfig¥Ú¡¼¥¸¤ÎÂ°À­ÃÍ°ìÍ÷¤ÇÄêµÁ¤·¤¿Í×ÁÇ¤¬´Ş¤Ş¤ì¤ì¤Ğ¡¢
-    // ¤½¤Î¸«½Ğ¤·¤ÎÃÍ¤òÊÖ¤¹
+    // (styleã®é©ç”¨æ™‚ã€listè¡¨ç¤ºå†…å®¹ã«ã€åˆ©ç”¨ã•ã‚Œã‚‹)
+    // å¼•æ•°(pageå†…ã®è©²å½“éƒ¨åˆ†)ã«configãƒšãƒ¼ã‚¸ã®å±æ€§å€¤ä¸€è¦§ã§å®šç¾©ã—ãŸè¦ç´ ãŒå«ã¾ã‚Œã‚Œã°ã€
+    // ãã®è¦‹å‡ºã—ã®å€¤ã‚’è¿”ã™
     function get_key($str)
     {
-        // ³ºÅö¥Õ¥£¡¼¥ë¥É¤ÎBlockPlugin¤ò°Ù¤¹Ê¸»úÎó¤«¤é0ÈÖÌÜ¤Î°ú¿ô¤Ë¤¢¤¿¤ëÊ¸»úÎó¤òÆÉ¤ß¼è¤ë
+        // è©²å½“ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ã®BlockPluginã‚’ç‚ºã™æ–‡å­—åˆ—ã‹ã‚‰0ç•ªç›®ã®å¼•æ•°ã«ã‚ãŸã‚‹æ–‡å­—åˆ—ã‚’èª­ã¿å–ã‚‹
         $arg= Tracker_plus_field_string_utility::get_argument_from_block_type_plugin_string($str);
         return $arg;
     }
   
-    // °ú¿ô(pageÆâ¤Î³ºÅöÉôÊ¬)¤Ëconfig¥Ú¡¼¥¸¤ÎÂ°À­ÃÍ°ìÍ÷¤ÇÄêµÁ¤·¤¿Í×ÁÇ¤¬´Ş¤Ş¤ì¤ì¤Ğ¡¢
-    // ¤½¤Î¸«½Ğ¤·¤ÎÃÍ¤òÊÖ¤¹(tracker_listÉ½¼¨¤Ç¡¢ÍøÍÑ¤µ¤ì¤Æ¤¤¤ë)
+    // å¼•æ•°(pageå†…ã®è©²å½“éƒ¨åˆ†)ã«configãƒšãƒ¼ã‚¸ã®å±æ€§å€¤ä¸€è¦§ã§å®šç¾©ã—ãŸè¦ç´ ãŒå«ã¾ã‚Œã‚Œã°ã€
+    // ãã®è¦‹å‡ºã—ã®å€¤ã‚’è¿”ã™(tracker_listè¡¨ç¤ºã§ã€åˆ©ç”¨ã•ã‚Œã¦ã„ã‚‹)
     function format_cell($str)
     {
         return $this->get_key($str);
@@ -1800,15 +1800,15 @@ class Tracker_field_select2 extends Tracker_field_select
 
 class Tracker_field_select3 extends Tracker_field_select2
 {
-    // (style¤ÎÅ¬ÍÑ»ş¡¢listÉ½¼¨ÆâÍÆ¤Ë¡¢ÍøÍÑ¤µ¤ì¤ë)
-    // °ú¿ô(pageÆâ¤Î³ºÅöÉôÊ¬)¤Ëconfig¥Ú¡¼¥¸¤ÎÂ°À­ÃÍ°ìÍ÷¤ÇÄêµÁ¤·¤¿Í×ÁÇ¤¬´Ş¤Ş¤ì¤ì¤Ğ¡¢
-    // ¤½¤Î¸«½Ğ¤·¤ÎÃÍ¤òÊÖ¤¹
+    // (styleã®é©ç”¨æ™‚ã€listè¡¨ç¤ºå†…å®¹ã«ã€åˆ©ç”¨ã•ã‚Œã‚‹)
+    // å¼•æ•°(pageå†…ã®è©²å½“éƒ¨åˆ†)ã«configãƒšãƒ¼ã‚¸ã®å±æ€§å€¤ä¸€è¦§ã§å®šç¾©ã—ãŸè¦ç´ ãŒå«ã¾ã‚Œã‚Œã°ã€
+    // ãã®è¦‹å‡ºã—ã®å€¤ã‚’è¿”ã™
     function get_key($str)
     {
-        // ³ºÅö¥Õ¥£¡¼¥ë¥É¤ÎBlockPlugin¤ò°Ù¤¹Ê¸»úÎó¤«¤é0ÈÖÌÜ¤Î°ú¿ô¤Ë¤¢¤¿¤ëÊ¸»úÎó¤òÆÉ¤ß¼è¤ë
+        // è©²å½“ãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰ã®BlockPluginã‚’ç‚ºã™æ–‡å­—åˆ—ã‹ã‚‰0ç•ªç›®ã®å¼•æ•°ã«ã‚ãŸã‚‹æ–‡å­—åˆ—ã‚’èª­ã¿å–ã‚‹
         $arg = Tracker_plus_field_string_utility::get_argument_from_block_type_plugin_string($str);
 
-        // config¥Ú¡¼¥¸¤ÇÀßÄê¤µ¤ì¤¿Â°À­ÃÍ¤ÈÈæ³Ó¤¹¤ë
+        // configãƒšãƒ¼ã‚¸ã§è¨­å®šã•ã‚ŒãŸå±æ€§å€¤ã¨æ¯”è¼ƒã™ã‚‹
         foreach( $this->config->get($this->name) as $option )
         {
             if( strcmp( $option[0], $arg) == 0 )
@@ -1833,39 +1833,39 @@ class Tracker_field_hidden2 extends Tracker_field_hidden
         $target_plugin_type = array_key_exists(2,$this->values) ?
           htmlspecialchars($this->values[2]) : 'block' ;
     
-        // ¥ª¥×¥·¥ç¥ó¤Î»ØÄê¤¬¤Ê¤±¤ì¤Ğ¡¢³ÈÄ¥½èÍı¤Ï¹Ô¤ï¤Ê¤¤
+        // ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã®æŒ‡å®šãŒãªã‘ã‚Œã°ã€æ‹¡å¼µå‡¦ç†ã¯è¡Œã‚ãªã„
         if( $extract_arg_num == '' )
         {
           return $value;
         }
 
-        // »ØÄê¤µ¤ì¤¿¥×¥é¥°¥¤¥ó¤«¤é°ÌÃÖ¤Î°ú¿ô¤òÃê½Ğ¤¹¤ë
+        // æŒ‡å®šã•ã‚ŒãŸãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‹ã‚‰ä½ç½®ã®å¼•æ•°ã‚’æŠ½å‡ºã™ã‚‹
         $arg = Tracker_plus_field_string_Utility::get_argument_from_plugin_string(
                 $value, $extract_arg_num, $target_plugin_name, $target_plugin_type);
 
         return $arg;
     }
 
-    // (sort¤ÎÅ¬ÍÑ»ş¤Ë¡¢ÍøÍÑ¤µ¤ì¤Æ¤¤¤ë)
-    // °ú¿ô(pageÆâ¤Î³ºÅöÉôÊ¬)¤ËÂĞ¤·¤Æ¡¢config¥Ú¡¼¥¸¤Î¥ª¥×¥·¥ç¥ó»ØÄê¤Ë½¾¤Ã¤Æ¡¢
-    // ¥Ö¥í¥Ã¥¯·¿¤Î¥×¥é¥°¥¤¥ó°ú¿ô¤«¤é»ØÄê¤µ¤ì¤¿ÉôÊ¬¤ÎÊ¸»úÎó¤ò
-    // ÀÚ¤ê½Ğ¤·¤¿ÃÍ¤òÊÖ¤¹½èÍı¤ò´Ş¤à
+    // (sortã®é©ç”¨æ™‚ã«ã€åˆ©ç”¨ã•ã‚Œã¦ã„ã‚‹)
+    // å¼•æ•°(pageå†…ã®è©²å½“éƒ¨åˆ†)ã«å¯¾ã—ã¦ã€configãƒšãƒ¼ã‚¸ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³æŒ‡å®šã«å¾“ã£ã¦ã€
+    // ãƒ–ãƒ­ãƒƒã‚¯å‹ã®ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å¼•æ•°ã‹ã‚‰æŒ‡å®šã•ã‚ŒãŸéƒ¨åˆ†ã®æ–‡å­—åˆ—ã‚’
+    // åˆ‡ã‚Šå‡ºã—ãŸå€¤ã‚’è¿”ã™å‡¦ç†ã‚’å«ã‚€
     function get_value($value)
     {
         return $this->extract_value($value);
     }
       
-    // °ú¿ô(pageÆâ¤Î³ºÅöÉôÊ¬)¤ËÂĞ¤·¤Æ¡¢
-    // config¥Ú¡¼¥¸¤Î¥ª¥×¥·¥ç¥ó»ØÄê¤Ë½¾¤Ã¤ÆÀÚ¤ê½Ğ¤·¤¿ÃÍ¤òÊÖ¤·¡¢
-    // pageÆâ¤Î³ºÅöÉôÊ¬¤Ëconfig¥Ú¡¼¥¸¤ÎÂ°À­ÃÍ°ìÍ÷¤ÇÄêµÁ¤·¤¿Í×ÁÇ¤¬´Ş¤Ş¤ì¤ì¤Ğ¡¢
-    // ¤½¤Î¸«½Ğ¤·¤ÎÃÍ¤òÊÖ¤¹¡Êstyle¤ÎÅ¬ÍÑ»ş¤Ë¡¢ÍøÍÑ¤µ¤ì¤Æ¤¤¤ë¡Ë
+    // å¼•æ•°(pageå†…ã®è©²å½“éƒ¨åˆ†)ã«å¯¾ã—ã¦ã€
+    // configãƒšãƒ¼ã‚¸ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³æŒ‡å®šã«å¾“ã£ã¦åˆ‡ã‚Šå‡ºã—ãŸå€¤ã‚’è¿”ã—ã€
+    // pageå†…ã®è©²å½“éƒ¨åˆ†ã«configãƒšãƒ¼ã‚¸ã®å±æ€§å€¤ä¸€è¦§ã§å®šç¾©ã—ãŸè¦ç´ ãŒå«ã¾ã‚Œã‚Œã°ã€
+    // ãã®è¦‹å‡ºã—ã®å€¤ã‚’è¿”ã™ï¼ˆstyleã®é©ç”¨æ™‚ã«ã€åˆ©ç”¨ã•ã‚Œã¦ã„ã‚‹ï¼‰
     function get_key($str)
     {
-        // °ú¿ô(pageÆâ¤Î³ºÅöÉôÊ¬)¤ËÂĞ¤·¤Æ¡¢config¥Ú¡¼¥¸¤Î¥ª¥×¥·¥ç¥ó»ØÄê¤Ë½¾¤Ã¤ÆÀÚ¤ê½Ğ¤¹¡£
+        // å¼•æ•°(pageå†…ã®è©²å½“éƒ¨åˆ†)ã«å¯¾ã—ã¦ã€configãƒšãƒ¼ã‚¸ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³æŒ‡å®šã«å¾“ã£ã¦åˆ‡ã‚Šå‡ºã™ã€‚
         $str= $this->extract_value($str);
         foreach( $this->config->get($this->name) as $option )
         {
-            // '/'Ê¸»ú¤¬ÁªÂò¸õÊäÊ¸»úÎó¤ËÆş¤Ã¤Æ¤â½èÍı¤Ç¤­¤ë¤è¤¦¤Ëescape¤¹¤ë
+            // '/'æ–‡å­—ãŒé¸æŠå€™è£œæ–‡å­—åˆ—ã«å…¥ã£ã¦ã‚‚å‡¦ç†ã§ãã‚‹ã‚ˆã†ã«escapeã™ã‚‹
             $eoption=preg_quote($option[0],'/');
             if( preg_match("/$eoption/",$str) )
             {
@@ -1875,14 +1875,14 @@ class Tracker_field_hidden2 extends Tracker_field_hidden
         return $str;
     }
   
-    // °ú¿ô(pageÆâ¤Î³ºÅöÉôÊ¬)¤ËÂĞ¤·¤Æ¡¢config¥Ú¡¼¥¸¤Î¥ª¥×¥·¥ç¥ó»ØÄê¤Ë½¾¤Ã¤ÆÀÚ¤ê½Ğ¤·¤¿ÃÍ¤òÊÖ¤·¡¢
-    // pageÆâ¤Î³ºÅöÉôÊ¬¤Ëconfig¥Ú¡¼¥¸¤ÎÂ°À­ÃÍ°ìÍ÷¤ÇÄêµÁ¤·¤¿Í×ÁÇ¤¬´Ş¤Ş¤ì¤ì¤Ğ¡¢
-    // ¤½¤Î¸«½Ğ¤·¤ÎÃÍ¤òÊÖ¤¹(tracker_listÉ½¼¨¤Ç¡¢ÍøÍÑ¤µ¤ì¤Æ¤¤¤ë)
+    // å¼•æ•°(pageå†…ã®è©²å½“éƒ¨åˆ†)ã«å¯¾ã—ã¦ã€configãƒšãƒ¼ã‚¸ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³æŒ‡å®šã«å¾“ã£ã¦åˆ‡ã‚Šå‡ºã—ãŸå€¤ã‚’è¿”ã—ã€
+    // pageå†…ã®è©²å½“éƒ¨åˆ†ã«configãƒšãƒ¼ã‚¸ã®å±æ€§å€¤ä¸€è¦§ã§å®šç¾©ã—ãŸè¦ç´ ãŒå«ã¾ã‚Œã‚Œã°ã€
+    // ãã®è¦‹å‡ºã—ã®å€¤ã‚’è¿”ã™(tracker_listè¡¨ç¤ºã§ã€åˆ©ç”¨ã•ã‚Œã¦ã„ã‚‹)
     function format_cell($str)
     {
         return $this->extract_value($str);
     }
-    // Page¤ØÅ¾µ­¤¹¤ëºİ¤ÎÃÍ¤òÊÖ¤¹
+    // Pageã¸è»¢è¨˜ã™ã‚‹éš›ã®å€¤ã‚’è¿”ã™
     function format_value($value,$post)
     {
         $str=$value;
@@ -1891,7 +1891,7 @@ class Tracker_field_hidden2 extends Tracker_field_hidden
         {
             if( preg_match("[$postkey]",$str) )
             {
-                // ÃÖ´¹¸õÊä¤¬ Array¤Ë¤Ê¤ë¾ì¹ç¤Ï¡¢ÇÛÎó¤«¤éÀèÆ¬Í×ÁÇ¤ò³ä¤êÅö¤Æ¤ë
+                // ç½®æ›å€™è£œãŒ Arrayã«ãªã‚‹å ´åˆã¯ã€é…åˆ—ã‹ã‚‰å…ˆé ­è¦ç´ ã‚’å‰²ã‚Šå½“ã¦ã‚‹
                 if( is_array($post[$postkey]) )
                 {
                   $str = str_replace("[$postkey]",array_shift($post[$postkey]),$str);
@@ -1908,10 +1908,10 @@ class Tracker_field_hidden2 extends Tracker_field_hidden
 class Tracker_field_hidden3 extends Tracker_field_hidden2
 {
     var $sort_type = SORT_NUMERIC;
-    // (sort¤ÎÅ¬ÍÑ»ş¤Ë¡¢ÍøÍÑ¤µ¤ì¤Æ¤¤¤ë)
-    // °ú¿ô(pageÆâ¤Î³ºÅöÉôÊ¬)¤ËÂĞ¤·¤Æ¡¢config¥Ú¡¼¥¸¤Î¥ª¥×¥·¥ç¥ó»ØÄê¤Ë½¾¤Ã¤Æ¡¢
-    // ¥Ö¥í¥Ã¥¯·¿¤Î¥×¥é¥°¥¤¥ó°ú¿ô¤«¤é»ØÄê¤µ¤ì¤¿ÉôÊ¬¤ÎÊ¸»úÎó¤ò
-    // ÀÚ¤ê½Ğ¤·¤¿ÃÍ¤òÊÖ¤¹½èÍı¤ò´Ş¤à
+    // (sortã®é©ç”¨æ™‚ã«ã€åˆ©ç”¨ã•ã‚Œã¦ã„ã‚‹)
+    // å¼•æ•°(pageå†…ã®è©²å½“éƒ¨åˆ†)ã«å¯¾ã—ã¦ã€configãƒšãƒ¼ã‚¸ã®ã‚ªãƒ—ã‚·ãƒ§ãƒ³æŒ‡å®šã«å¾“ã£ã¦ã€
+    // ãƒ–ãƒ­ãƒƒã‚¯å‹ã®ãƒ—ãƒ©ã‚°ã‚¤ãƒ³å¼•æ•°ã‹ã‚‰æŒ‡å®šã•ã‚ŒãŸéƒ¨åˆ†ã®æ–‡å­—åˆ—ã‚’
+    // åˆ‡ã‚Šå‡ºã—ãŸå€¤ã‚’è¿”ã™å‡¦ç†ã‚’å«ã‚€
     function extract_value($value)
     {
         $extract_arg_num = (array_key_exists(0,$this->values) and is_numeric($this->values[0])) ?
@@ -1921,17 +1921,17 @@ class Tracker_field_hidden3 extends Tracker_field_hidden2
         $target_plugin_type = array_key_exists(2,$this->values) ?
           htmlspecialchars($this->values[2]) : 'block' ;
     
-        // ¥ª¥×¥·¥ç¥ó¤Î»ØÄê¤¬¤Ê¤±¤ì¤Ğ¡¢³ÈÄ¥½èÍı¤Ï¹Ô¤ï¤Ê¤¤
+        // ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã®æŒ‡å®šãŒãªã‘ã‚Œã°ã€æ‹¡å¼µå‡¦ç†ã¯è¡Œã‚ãªã„
         if( $extract_arg_num == '' )
         {
           return $value;
         }
 
-        // »ØÄê¤µ¤ì¤¿¥×¥é¥°¥¤¥ó¤«¤é°ÌÃÖ¤Î°ú¿ô¤òÃê½Ğ¤¹¤ë
+        // æŒ‡å®šã•ã‚ŒãŸãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‹ã‚‰ä½ç½®ã®å¼•æ•°ã‚’æŠ½å‡ºã™ã‚‹
         $arg = Tracker_plus_field_string_Utility::get_argument_from_plugin_string(
                 $value, $extract_arg_num, $target_plugin_name, $target_plugin_type);
 
-        // Ãê½Ğ¤·¤¿Ê¸»úÎó¤«¤é¿ôÃÍ¤Ç¤¢¤ëÉôÊ¬¤Î¤ß¤òÃê½Ğ¤·¡¢¥½¡¼¥È¤äÉ½¼¨¤Î½èÍıÂĞ¾İ¤È¤¹¤ë
+        // æŠ½å‡ºã—ãŸæ–‡å­—åˆ—ã‹ã‚‰æ•°å€¤ã§ã‚ã‚‹éƒ¨åˆ†ã®ã¿ã‚’æŠ½å‡ºã—ã€ã‚½ãƒ¼ãƒˆã‚„è¡¨ç¤ºã®å‡¦ç†å¯¾è±¡ã¨ã™ã‚‹
         $arg = (preg_match("/(\d+)/",$arg,$match) ) ? $match[1] : 0;
 
         return $arg;
@@ -1981,12 +1981,12 @@ class Tracker_field_datefield extends Tracker_field
         $s_month = date("m",time()); 
         $s_date  = date("d",time()); 
         
-        // ¥Ç¥Õ¥©¥ë¥ÈÃÍ¤ò¸½ºß¤ÎÆüÉÕ¤Ë¤¹¤ë
+        // ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆå€¤ã‚’ç¾åœ¨ã®æ—¥ä»˜ã«ã™ã‚‹
         if( $s_value=="TODAY" )
         {
           $s_value = $this->get_datestr_with_format($s_format, $s_year, $s_month, $s_date);
         }
-        // Javascript¤Ë°ú¤­¤ï¤¿¤¹·Á¼°¤Î¥Õ¥©¡¼¥Ş¥Ã¥ÈÊ¸»úÎó¤ËÊÑ¹¹¤¹¤ë
+        // Javascriptã«å¼•ãã‚ãŸã™å½¢å¼ã®ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆæ–‡å­—åˆ—ã«å¤‰æ›´ã™ã‚‹
         $s_format = $this->form_format($s_format);
         
         return <<<EOD
@@ -1995,21 +1995,21 @@ class Tracker_field_datefield extends Tracker_field
 EOD;
     }
   
-    // sort¤ÎÅ¬ÍÑ»ş¤Ë¡¢¤½¤ÎÃÍ¤ò°Ê¤Ã¤Æ½èÍı¤ò¹Ô¤ï¤»¤ë¡£
-    // ³ºÅöÉôÊ¬¤Ë´Ş¤Ş¤ì¤ë¥Ö¥í¥Ã¥¯¥×¥é¥°¥¤¥ó¤Î0ÈÖÌÜ¤Î°ú¿ô¤òÊÖ¤¹
+    // sortã®é©ç”¨æ™‚ã«ã€ãã®å€¤ã‚’ä»¥ã£ã¦å‡¦ç†ã‚’è¡Œã‚ã›ã‚‹ã€‚
+    // è©²å½“éƒ¨åˆ†ã«å«ã¾ã‚Œã‚‹ãƒ–ãƒ­ãƒƒã‚¯ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã®0ç•ªç›®ã®å¼•æ•°ã‚’è¿”ã™
     function get_value($value)
     {
         $arg= Tracker_plus_field_string_utility::get_argument_from_block_type_plugin_string($value,0,'datefield');
         return $arg;
     }
 
-    // tracker_listÉ½¼¨¤Ç¤Î¡¢½ĞÎÏÆâÍÆ¤òÊÖ¤¹
+    // tracker_listè¡¨ç¤ºã§ã®ã€å‡ºåŠ›å†…å®¹ã‚’è¿”ã™
     function format_cell($str)
     {
         return $this->get_value($str);
     }
   
-    // Page¤ØÅ¾µ­¤¹¤ëºİ¤ÎÃÍ¤òÊÖ¤¹
+    // Pageã¸è»¢è¨˜ã™ã‚‹éš›ã®å€¤ã‚’è¿”ã™
     function format_value($value)
     {
         $s_format = (array_key_exists(1,$this->values)) ? htmlspecialchars($this->values[1]) : 'YYYY-MM-DD';
@@ -2039,7 +2039,7 @@ EOD;
 
     function get_datestr_with_format($format_opt,$yyyy,$mm,$dd )
     {
-        // °ú¿ô¤Î·î¤ÎÃÍ¤ÎÈÏ°Ï month is 1 - 12
+        // å¼•æ•°ã®æœˆã®å€¤ã®ç¯„å›² month is 1 - 12
         $strWithFormat = $format_opt;
         $yy = $yyyy%100;
         
@@ -2062,7 +2062,7 @@ EOD;
         if( ! isset($pkwk_dtd) || $pkwk_dtd == PKWK_DTD_XHTML_1_1 )
             $pkwk_dtd = PKWK_DTD_XHTML_1_0_TRANSITIONAL;
         
-        // <head> ¥¿¥°Æâ¤Ø¤Î <meta>Àë¸À¤ÎÄÉ²Ã
+        // <head> ã‚¿ã‚°å†…ã¸ã® <meta>å®£è¨€ã®è¿½åŠ 
         $javascript = TRUE;
     }
 }
@@ -2083,7 +2083,7 @@ class Tracker_plus_field_string_utility {
         
         $matches = array();
 
-        // Ê£¿ô¤Îplugin»ØÄê¤¬Â¸ºß¤¹¤ë¾ì¹ç¤Ç¤âÁ´¤Æ¤ËÂĞ¤·¤ÆÃê½Ğ¤ò¹Ô¤¦
+        // è¤‡æ•°ã®pluginæŒ‡å®šãŒå­˜åœ¨ã™ã‚‹å ´åˆã§ã‚‚å…¨ã¦ã«å¯¾ã—ã¦æŠ½å‡ºã‚’è¡Œã†
         if( preg_match_all("/(?:$str_plugin\(([^\)]*)\))/", $str, $matches, PREG_SET_ORDER) )
         {
             $paddata = preg_split("/$str_plugin\([^\)]*\)/", $str);
@@ -2103,9 +2103,9 @@ class Tracker_plus_field_string_utility {
                     $extract_arg = $str_plugin . $str_arg;
                 }
             }
-            // block-type,inline-type ¤Î¥×¥é¥°¥¤¥ó»ØÄê¤Ë¤ª¤¤¤Æ¡¢
-            // ºÇ¸å¤Î³ç¸Ì¤Î¸å¤Ë¥»¥ß¥³¥í¥ó¤¬¤¢¤ë¾ì¹ç¤È¤Ê¤¤¾ì¹ç¤¬Â¸ºß¤¹¤ë¤¿¤á¡¢
-            // ¥»¥ß¥³¥í¥ó¤¬Ä¾¸å¤Ë¤¢¤Ã¤¿¾ì¹ç¤Ï¡¢¥×¥é¥°¥¤¥ó»ØÄê¤Î°ìÉô¤ÈÂª¤¨¤Æ½üµî¤ò¹Ô¤¦
+            // block-type,inline-type ã®ãƒ—ãƒ©ã‚°ã‚¤ãƒ³æŒ‡å®šã«ãŠã„ã¦ã€
+            // æœ€å¾Œã®æ‹¬å¼§ã®å¾Œã«ã‚»ãƒŸã‚³ãƒ­ãƒ³ãŒã‚ã‚‹å ´åˆã¨ãªã„å ´åˆãŒå­˜åœ¨ã™ã‚‹ãŸã‚ã€
+            // ã‚»ãƒŸã‚³ãƒ­ãƒ³ãŒç›´å¾Œã«ã‚ã£ãŸå ´åˆã¯ã€ãƒ—ãƒ©ã‚°ã‚¤ãƒ³æŒ‡å®šã®ä¸€éƒ¨ã¨æ‰ãˆã¦é™¤å»ã‚’è¡Œã†
             if( preg_match("/^\;.*$/",$paddata[$i+1],$exrep) && count($exrep) > 1 )
             {
                 $paddata[$i+1] = $exrep[1];

--- a/tracker_summary_item.inc.php/tracker_summary_item.inc.php
+++ b/tracker_summary_item.inc.php/tracker_summary_item.inc.php
@@ -6,7 +6,7 @@
 //
 // License   : GNU General Public License (GPL) 
 // 
-// 1ÉÃ¤ÎÂç¤­¤µ¤ÎÄêµÁ
+// 1ç§’ã®å¤§ãã•ã®å®šç¾©
 define ('TRACKER_SUMMARY_ITEM_TIME_TYPE_SEC'  ,1);
 define ('TRACKER_SUMMARY_ITEM_TIME_TYPE_MSEC' ,1000);
 define ('TRACKER_SUMMARY_ITEM_TIME_TYPE_FILM' ,24);
@@ -63,7 +63,7 @@ function plugin_tracker_summary_item_convert()
 
 	if( $isSuccess )
 	{
-		return $title . '¤Î¹ç·×¡§' . $sum;
+		return $title . 'ã®åˆè¨ˆï¼š' . $sum;
 	}
 	else
 	{
@@ -155,7 +155,7 @@ function plugin_tracker_summary_item_getsum($page, $refer, $config_name, $list,
 		return array( $isSuccess, $errmsg, $title , $sum);
 	}
 
-	// $list ÊÑ¿ô¤¬ÊÌ¤Î°ÕÌ£¤Ç»È¤¤¤Ş¤ï¤µ¤ì¤Æ¤¤¤ë¤Î¤ÇÃí°Õ!! (jjyun's comment)
+	// $list å¤‰æ•°ãŒåˆ¥ã®æ„å‘³ã§ä½¿ã„ã¾ã‚ã•ã‚Œã¦ã„ã‚‹ã®ã§æ³¨æ„!! (jjyun's comment)
 	$list = &new Tracker_plus_list($page,$refer,$config,$list,$filter_name,$cache);
 
 	if($filter_name != NULL)
@@ -163,7 +163,7 @@ function plugin_tracker_summary_item_getsum($page, $refer, $config_name, $list,
 		$filter_config = new Tracker_plus_FilterConfig('plugin/tracker/'.$config->config_name.'/filters');
 		if( ! $filter_config->read() )
 		{
-			// filter¤ÎÀßÄê¤¬¤Ê¤µ¤ì¤Æ¤¤¤Ê¤±¤ì¤Ğ, ¥¨¥é¡¼¥í¥°¤òÊÖ¤¹
+			// filterã®è¨­å®šãŒãªã•ã‚Œã¦ã„ãªã‘ã‚Œã°, ã‚¨ãƒ©ãƒ¼ãƒ­ã‚°ã‚’è¿”ã™
 			$errmsg = "config file '".htmlspecialchars($config->page.'/filters')."' not found.";
 			return array( $isSuccess, $errmsg, $title , $sum);
 		}
@@ -190,7 +190,7 @@ function plugin_tracker_summary_item_getsum($page, $refer, $config_name, $list,
 
 	if( $summary_calc->target_name == '_line' )
 	{ 
-		$title = '¥ê¥¹¥È·ï¿ô';
+		$title = 'ãƒªã‚¹ãƒˆä»¶æ•°';
 		$sum = $summary_calc->get_count();
 	}
 	else 
@@ -349,7 +349,7 @@ class Tracker_summary_item_DATA_TYPE_TIME extends Tracker_summary_item_DATA_TYPE
 		if( $output_data_type != TRACKER_SUMMARY_ITEM_TIME_TYPE_SEC && 
 		    $this->data_type != $output_data_type )
 		{
-			$this->errMsg = "Æş½ĞÎÏ¥Õ¥©¡¼¥Ş¥Ã¥È´Ö¤Ë¡¢¸ß´¹À­¤Î¤Ê¤¤»ØÄê¤¬¤Ê¤µ¤ì¤Æ¤¤¤Ş¤¹¡£";
+			$this->errMsg = "å…¥å‡ºåŠ›ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆé–“ã«ã€äº’æ›æ€§ã®ãªã„æŒ‡å®šãŒãªã•ã‚Œã¦ã„ã¾ã™ã€‚";
 			return FALSE;
 		}
 
@@ -368,20 +368,20 @@ class Tracker_summary_item_DATA_TYPE_TIME extends Tracker_summary_item_DATA_TYPE
 
 		// === format check part ===
 
-		// ¥¯¥©¡¼¥ÈÊ¸»ú¤ÎÂ¸ºß³ÎÇ§
+		// ã‚¯ã‚©ãƒ¼ãƒˆæ–‡å­—ã®å­˜åœ¨ç¢ºèª
 		if( preg_match('/^.*[\'\"].*$/',$formatReg) ){ /* match character..." ' */
-		  $this->errMsg = sprintf("»ş´Ö½ñ¼°Ê¸»úÎó %s ¤Ë¥¯¥©¡¼¥ÈÊ¸»ú(&nbsp;&#039;&nbsp;&quot;&nbsp;)¤ò»ÈÍÑ¤·¤Ê¤¤¤Ç¤¯¤À¤µ¤¤", $formatStr);
+		  $this->errMsg = sprintf("æ™‚é–“æ›¸å¼æ–‡å­—åˆ— %s ã«ã‚¯ã‚©ãƒ¼ãƒˆæ–‡å­—(&nbsp;&#039;&nbsp;&quot;&nbsp;)ã‚’ä½¿ç”¨ã—ãªã„ã§ãã ã•ã„", $formatStr);
 		  return FALSE;
 		}
 
-		/* ÆşÎÏÃÍ¤È»ş¹ï½ñ¼°¤È¤ÎÈæ³Ó */
+		/* å…¥åŠ›å€¤ã¨æ™‚åˆ»æ›¸å¼ã¨ã®æ¯”è¼ƒ */
 		// - available time format - 
 		// H:hour , M:minute, S:sec 
 		// F:FILM, N:NTSC, P:PAL , m:millisec 
 
 		// duplication check in format 
 		$dupcheck=count_chars($formatReg);
-		$f_dupcnt=0; // variable for checking for 1ÉÃ°Ê²¼¤ÎÃ±°Ì
+		$f_dupcnt=0; // variable for checking for 1ç§’ä»¥ä¸‹ã®å˜ä½
 		$time_formats = array("H","M","S","m","F","P","N");
 		foreach($time_formats as $unit)
 		{
@@ -389,11 +389,11 @@ class Tracker_summary_item_DATA_TYPE_TIME extends Tracker_summary_item_DATA_TYPE
 			{
 				if($dupcheck[ord($unit)] > 1 )
 				{
-				  $this->errMsg = sprintf("»ş´Ö½ñ¼°Ê¸»úÎó %s ¤Ë»ş¹ï»ØÄê»Ò¤Î½ÅÊ£¤¬¤¢¤ê¤Ş¤¹¡£", $formatStr);
+				  $this->errMsg = sprintf("æ™‚é–“æ›¸å¼æ–‡å­—åˆ— %s ã«æ™‚åˆ»æŒ‡å®šå­ã®é‡è¤‡ãŒã‚ã‚Šã¾ã™ã€‚", $formatStr);
 				  return FALSE;
 			  }
 			  
-			// 1ÉÃ°Ê²¼¤ÎÃ±°Ì¤Î½ÅÊ£³ÎÇ§
+			// 1ç§’ä»¥ä¸‹ã®å˜ä½ã®é‡è¤‡ç¢ºèª
 			  if( $unit == "m" || $unit == "F" || 
 			      $unit == "P" || $unit == "N" ) 
 			  {
@@ -404,7 +404,7 @@ class Tracker_summary_item_DATA_TYPE_TIME extends Tracker_summary_item_DATA_TYPE
 		}
 		if( $f_dupcnt > 1)
 		{
-			$this->errMsg = sprintf("»ş´Ö½ñ¼°Ê¸»úÎó %s ¤ËÉÃ°Ê²¼¤Î¥Õ¥©¡¼¥Ş¥Ã¥È¤¬½ÅÊ£¤·¤Æ¤Ş¤¹¡£", $formatStr);
+			$this->errMsg = sprintf("æ™‚é–“æ›¸å¼æ–‡å­—åˆ— %s ã«ç§’ä»¥ä¸‹ã®ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆãŒé‡è¤‡ã—ã¦ã¾ã™ã€‚", $formatStr);
 			return FALSE;
 		}
 		return TRUE;
@@ -427,7 +427,7 @@ class Tracker_summary_item_DATA_TYPE_TIME extends Tracker_summary_item_DATA_TYPE
 		  $msecFormat='%03d';
 		}
 
-		// ¶èÀÚ¤êÊ¸»ú¤¬ '/'(¥Ğ¥Ã¥¯¥¹¥é¥Ã¥·¥å)¤Î¾ì¹ç¤Ï¥¨¥¹¥±¡¼¥×Ê¸»ú¤òÉÕÍ¿¤¹¤ë
+		// åŒºåˆ‡ã‚Šæ–‡å­—ãŒ '/'(ãƒãƒƒã‚¯ã‚¹ãƒ©ãƒƒã‚·ãƒ¥)ã®å ´åˆã¯ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—æ–‡å­—ã‚’ä»˜ä¸ã™ã‚‹
 		$formatPtn = preg_replace('/\//','\\/',$formatStr);
 
 		$formatPtn = preg_replace('/(H|M|S)/',$numFormat,$formatPtn);
@@ -473,10 +473,10 @@ class Tracker_summary_item_DATA_TYPE_TIME extends Tracker_summary_item_DATA_TYPE
 	function makeVariableArgsPtn($formatStr,$isInput)
 	{
 		// making timeArgs
-		// ¶èÀÚ¤êÊ¸»ú¤¬ '/'(¥Ğ¥Ã¥¯¥¹¥é¥Ã¥·¥å)¤Î¾ì¹ç¤Ï¥¨¥¹¥±¡¼¥×Ê¸»ú¤òÉÕÍ¿¤¹¤ë
+		// åŒºåˆ‡ã‚Šæ–‡å­—ãŒ '/'(ãƒãƒƒã‚¯ã‚¹ãƒ©ãƒƒã‚·ãƒ¥)ã®å ´åˆã¯ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—æ–‡å­—ã‚’ä»˜ä¸ã™ã‚‹
 		$timeArgs =  preg_replace('/\//','\\/',$formatStr);
 
-		// ¾®Ê¸»ú¤Î 'm' ¤òÀè¤Ë½èÍı¤¹¤ëÉ¬Í×¤¬¤¢¤ë
+		// å°æ–‡å­—ã® 'm' ã‚’å…ˆã«å‡¦ç†ã™ã‚‹å¿…è¦ãŒã‚ã‚‹
 		if( $isInput) 
 		{
 			$timeArgs =  preg_replace('/m/',',\$msec', $timeArgs);
@@ -509,10 +509,10 @@ class Tracker_summary_item_DATA_TYPE_TIME extends Tracker_summary_item_DATA_TYPE
 
 	function getValue($dataStr) // in other words, this is parseStr(). 
 	{
-		// ¶èÀÚ¤êÊ¸»ú¤¬ '/'(¥Ğ¥Ã¥¯¥¹¥é¥Ã¥·¥å)¤Î¾ì¹ç¤Ï¥¨¥¹¥±¡¼¥×Ê¸»ú¤òÉÕÍ¿¤¹¤ë
+		// åŒºåˆ‡ã‚Šæ–‡å­—ãŒ '/'(ãƒãƒƒã‚¯ã‚¹ãƒ©ãƒƒã‚·ãƒ¥)ã®å ´åˆã¯ã‚¨ã‚¹ã‚±ãƒ¼ãƒ—æ–‡å­—ã‚’ä»˜ä¸ã™ã‚‹
 		$scanStr = preg_replace('/\//','\\/',$dataStr);
 		
-		// Äê¿ô¤¬ÆşÎÏ¤µ¤ì¤Æ¤¤¤¿¾ì¹ç
+		// å®šæ•°ãŒå…¥åŠ›ã•ã‚Œã¦ã„ãŸå ´åˆ
 		if(strcmp($scanStr,$this->inputFormatPtn) == 0)
 		{
 			return 0;
@@ -546,7 +546,7 @@ class Tracker_summary_item_DATA_TYPE_TIME extends Tracker_summary_item_DATA_TYPE
 	{
 		$hour = $min = $sec = $ftime = -1;
 
-		// 1ÉÃ°Ê²¼¤ÎÃÍ¤ÎÀÚ¤ê½Ğ¤·
+		// 1ç§’ä»¥ä¸‹ã®å€¤ã®åˆ‡ã‚Šå‡ºã—
 		$ftime = $sumValue % $this->data_type ;
 		$sec = floor($sumValue / $this->data_type) ;
 


### PR DESCRIPTION
こんにちは。tracker_plusの公開ありがとうございました。
最近のPukiWikiはUTF-8で使われることが多いので、プラグイン中のコメントやリソースも
UTF-8にすることで、利用しやすくなると思っています。
ソースコードをすべてUTF-8に変更をお願いしたいです。

UTF-8変換に際して、考えられる方法は2つ考えられます。

* (a) 最新のソースをEUC-JPからUTF-8に変換する (このPull Request)
  * Pros: 履歴が正しい（変更当時のソースコードがそのまま残る）
  * Cons: 過去の履歴が見にくくなる (UTF-8前提のツールで表示すると文字化け)
* (b) 過去のソースをすべてUTF-8であったとして書き換える (git filter-branch)
  * 履歴を参照したかったのでここに変換してみました: https://github.com/umorigu/twilight-breeze-pukiwiki-plugins
  * Pros: UTF-8前提の各種ツールでも過去の変更を容易に参照できる
  * Cons: 履歴が改変されてしまい、ソースコードの正確さが失われる (EUC-JPに依存した実装があれば、壊れる)

どちらかの対応をお願いしたいです。一般的なのはやはり(a)であると思います。PukiWiki本体も(a)で対応しました。

あるいは、このPRをマージしなくても以下のシェルスクリプト(UNIXまたはWindowsのGit Bash)をmasterに適用することでも、同じ変更になります。

(PukiWiki 1.5.1/PHP7 対応には別の変更が要ります。前準備としてのUTF-8変換です)

よろしくお願いします。

----

Convert EUC-JP(CP51932) to UTF-8 by using following shell script.

```
LIST="
datefield.inc.php/datefield.css
datefield.inc.php/datefield.inc.php
datefield.inc.php/datefield.js-layer
datefield.inc.php/datefield.js-subwin
linkvote.inc.php/linkvote.inc.php
listbox3.inc.php/listbox3.inc.php
listbox3.inc.php/listbox3.js
memox.inc.php/memox.inc.php
pages2csv.inc.php/pages2csv.inc.php
tracker_plus.inc.php/tracker_plus.inc.php
tracker_plus.inc.php/tracker_plus_list.inc.php
tracker_summary_item.inc.php/tracker_summary_item.inc.php
"

for F in $LIST; do
  php -r 'file_put_contents($argv[2],mb_convert_encoding(
    file_get_contents($argv[1]),"UTF-8","CP51932"));' $F $F
done
```